### PR TITLE
Bootstrap normal2disp package with CLI and inspect command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.venv/
+__pycache__/
+*.pyc
+normal2disp.egg-info/

--- a/normal2disp/__init__.py
+++ b/normal2disp/__init__.py
@@ -1,0 +1,8 @@
+"""Top-level package for normal2disp."""
+
+from . import n2d as _n2d
+
+__all__ = ["n2d", "__version__", "get_version"]
+
+__version__ = _n2d.__version__
+get_version = _n2d.get_version

--- a/normal2disp/n2d/__init__.py
+++ b/normal2disp/n2d/__init__.py
@@ -1,0 +1,17 @@
+"""Core package metadata and helpers for normal2disp."""
+
+from __future__ import annotations
+
+from importlib import metadata
+
+__all__ = ["__version__", "get_version"]
+
+__version__ = "0.1.0"
+
+
+def get_version() -> str:
+    """Return the installed package version."""
+    try:
+        return metadata.version("normal2disp")
+    except metadata.PackageNotFoundError:
+        return __version__

--- a/normal2disp/n2d/bake.py
+++ b/normal2disp/n2d/bake.py
@@ -1,0 +1,40 @@
+"""Displacement bake orchestration (stub for future phases)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, List, Optional, Tuple
+from typing import Literal
+
+NormalizationMode = Literal["auto", "xyz", "xy", "none"]
+LoaderMode = Literal["auto", "pyassimp", "blender"]
+
+
+@dataclass
+class BakeOptions:
+    """Options that configure the displacement baking process."""
+
+    uv_set: Optional[str] = None
+    y_is_down: bool = False
+    normalization: NormalizationMode = "auto"
+    max_slope: float = 10.0
+    amplitude: float = 1.0
+    cg_tol: float = 1e-6
+    cg_maxiter: int = 10000
+    deterministic: bool = False
+    processes: Optional[int] = None
+    loader: LoaderMode = "auto"
+    export_sidecars: bool = False
+    on_progress: Optional[Callable[[str, float], None]] = None
+
+
+def bake(
+    mesh_path: Path,
+    normal_pattern: str,
+    output_pattern: str,
+    options: Optional[BakeOptions] = None,
+) -> Tuple[List[Path], List[str], List[Path]]:
+    """Placeholder for the future baking pipeline implementation."""
+
+    raise NotImplementedError("Bake pipeline will be implemented in a later phase.")

--- a/normal2disp/n2d/cli.py
+++ b/normal2disp/n2d/cli.py
@@ -1,0 +1,114 @@
+"""Command line interface for the ``n2d`` tool."""
+
+from __future__ import annotations
+
+import json
+import logging
+from importlib import import_module
+from pathlib import Path
+from typing import Any, Dict, List, Tuple
+
+import click
+from rich.console import Console
+from rich.table import Table
+
+from . import get_version
+from .core import MeshLoadError
+from .inspect import run_inspect
+
+__all__ = ["main"]
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def _configure_logging(verbose: bool) -> None:
+    level = logging.DEBUG if verbose else logging.INFO
+    logging.basicConfig(level=level, format="%(levelname)s:%(name)s:%(message)s")
+    _LOGGER.debug("Logging configured (level=%s)", logging.getLevelName(level))
+
+
+def _probe_module(module_name: str) -> Tuple[bool, str | None]:
+    try:
+        module = import_module(module_name)
+    except Exception as exc:  # pragma: no cover - import failure depends on environment
+        return False, str(exc)
+
+    version = getattr(module, "__version__", None)
+    if module_name == "OpenImageIO" and version is None:
+        version = getattr(module, "VERSION", None)
+        if isinstance(version, int):
+            version = str(version)
+    detail = f"v{version}" if version else None
+    return True, detail
+
+
+@click.group()
+@click.option("--verbose", is_flag=True, help="Enable verbose logging output")
+@click.pass_context
+def main(ctx: click.Context, verbose: bool) -> None:
+    """Entrypoint for the ``n2d`` command."""
+
+    _configure_logging(verbose)
+    ctx.ensure_object(dict)
+    ctx.obj["console"] = Console()
+
+
+@main.command()
+def version() -> None:
+    """Show package version and capability probes."""
+
+    pkg_version = get_version()
+    click.echo(f"normal2disp {pkg_version}")
+
+    for module_name in ("OpenImageIO", "pyassimp"):
+        available, detail = _probe_module(module_name)
+        status = "yes" if available else "no"
+        if detail:
+            status = f"{status} ({detail})"
+        click.echo(f"{module_name}: {status}")
+
+
+@main.command(name="inspect")
+@click.argument("mesh_path", type=click.Path(path_type=Path, exists=True, dir_okay=False))
+@click.option(
+    "--inspect-json",
+    type=click.Path(path_type=Path),
+    help="Write the inspection report to this JSON file.",
+)
+@click.pass_context
+def inspect_command(ctx: click.Context, mesh_path: Path, inspect_json: Path | None) -> None:
+    """Inspect mesh UV sets and UDIM coverage."""
+
+    try:
+        report = run_inspect(mesh_path)
+    except MeshLoadError as exc:
+        raise click.ClickException(str(exc)) from exc
+    except Exception as exc:  # pragma: no cover - safeguard
+        raise click.ClickException(f"Failed to inspect mesh: {exc}") from exc
+
+    ctx_obj: Dict[str, Any] = ctx.obj if isinstance(ctx.obj, dict) else {}
+    console = ctx_obj.get("console")
+    if not isinstance(console, Console):
+        console = Console()
+    table = Table(title=str(mesh_path))
+    table.add_column("UV Set")
+    table.add_column("Charts", justify="right")
+    table.add_column("UDIMs")
+
+    uv_sets: List[Dict[str, Any]] = list(report.get("uv_sets", []))
+    if not uv_sets:
+        table.add_row("—", "0", "—")
+    else:
+        for uv_set in uv_sets:
+            udims = uv_set.get("udims", [])
+            udim_text = ", ".join(str(tile) for tile in udims) if udims else "—"
+            table.add_row(uv_set.get("name", "UV"), str(uv_set.get("chart_count", 0)), udim_text)
+
+    console.print(table)
+
+    if inspect_json is not None:
+        inspect_json.parent.mkdir(parents=True, exist_ok=True)
+        with inspect_json.open("w", encoding="utf-8") as handle:
+            json.dump(report, handle, indent=2)
+            handle.write("\n")
+        console.print(f"[green]Wrote inspection report to {inspect_json}[/green]")

--- a/normal2disp/n2d/core.py
+++ b/normal2disp/n2d/core.py
@@ -1,0 +1,13 @@
+"""Core types and exceptions for normal2disp."""
+
+from __future__ import annotations
+
+__all__ = ["N2DError", "MeshLoadError"]
+
+
+class N2DError(Exception):
+    """Base exception for normal2disp errors."""
+
+
+class MeshLoadError(N2DError):
+    """Raised when a mesh cannot be loaded."""

--- a/normal2disp/n2d/image_utils.py
+++ b/normal2disp/n2d/image_utils.py
@@ -1,0 +1,5 @@
+"""Image I/O helpers (implemented in later phases)."""
+
+from __future__ import annotations
+
+__all__ = []

--- a/normal2disp/n2d/inspect.py
+++ b/normal2disp/n2d/inspect.py
@@ -1,0 +1,80 @@
+"""Mesh inspection helpers for the ``n2d inspect`` CLI command."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any, Dict, List
+
+import numpy as np
+
+from .core import MeshLoadError
+
+__all__ = ["run_inspect"]
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def run_inspect(mesh_path: Path) -> Dict[str, Any]:
+    """Inspect ``mesh_path`` and return a serialisable report."""
+
+    resolved_path = mesh_path.expanduser().resolve()
+    try:
+        from pyassimp import errors as pyassimp_errors
+        from pyassimp import load as assimp_load
+    except ImportError as exc:  # pragma: no cover - handled in runtime
+        raise MeshLoadError("pyassimp is required for mesh inspection") from exc
+
+    try:
+        with assimp_load(str(resolved_path)) as scene:
+            if not scene.meshes:
+                raise MeshLoadError(f"Mesh '{resolved_path}' does not contain any geometry")
+            mesh = scene.meshes[0]
+            uv_sets = _extract_uv_sets(mesh)
+    except pyassimp_errors.AssimpError as exc:
+        raise MeshLoadError(f"Failed to load mesh '{resolved_path}': {exc}") from exc
+
+    report = {
+        "mesh_path": str(resolved_path),
+        "uv_sets": uv_sets,
+    }
+    _LOGGER.debug("Inspection report generated: %s", report)
+    return report
+
+
+def _extract_uv_sets(mesh: Any) -> List[Dict[str, Any]]:
+    uv_sets: List[Dict[str, Any]] = []
+    coords_sequences = getattr(mesh, "texturecoords", [])
+    component_counts = getattr(mesh, "numuvcomponents", [])
+
+    for index, coords in enumerate(coords_sequences):
+        if coords is None:
+            continue
+        components = int(component_counts[index]) if index < len(component_counts) else 0
+        if components < 2:
+            continue
+
+        uv_array = np.asarray(coords, dtype=np.float64)
+        if uv_array.ndim != 2 or uv_array.shape[0] == 0:
+            udims: List[int] = []
+        else:
+            uv_2d = uv_array[:, :2]
+            finite_mask = np.isfinite(uv_2d).all(axis=1)
+            if not finite_mask.any():
+                udims = []
+            else:
+                valid_uv = uv_2d[finite_mask]
+                tiles_u = np.floor(valid_uv[:, 0])
+                tiles_v = np.floor(valid_uv[:, 1])
+                tiles = 1001 + tiles_u.astype(int) + 10 * tiles_v.astype(int)
+                udims = sorted({int(tile) for tile in tiles})
+
+        uv_sets.append(
+            {
+                "name": f"UV{index}",
+                "chart_count": 0,
+                "udims": udims,
+            }
+        )
+
+    return uv_sets

--- a/normal2disp/n2d/mesh_utils.py
+++ b/normal2disp/n2d/mesh_utils.py
@@ -1,0 +1,5 @@
+"""Mesh loading and analysis helpers (future implementation)."""
+
+from __future__ import annotations
+
+__all__ = []

--- a/normal2disp/n2d/uv_raster.py
+++ b/normal2disp/n2d/uv_raster.py
@@ -1,0 +1,5 @@
+"""UV rasterization utilities (to be implemented in later phases)."""
+
+from __future__ import annotations
+
+__all__ = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,29 @@
+[build-system]
+requires = ["setuptools>=66", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "normal2disp"
+version = "0.1.0"
+description = "Tangent-space normal map to displacement converter."
+readme = "README.md"
+requires-python = ">=3.10"
+dependencies = []
+
+[project.scripts]
+n2d = "normal2disp.n2d.cli:main"
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["normal2disp*"]
+
+[tool.black]
+line-length = 100
+target-version = ["py312"]
+
+[tool.ruff]
+line-length = 100
+target-version = "py312"
+
+[tool.pytest.ini_options]
+addopts = "-q"


### PR DESCRIPTION
## Summary
- configure pyproject metadata and linting/formatting defaults for the new normal2disp package
- add the initial CLI with version probing and mesh inspection capabilities
- scaffold core modules (inspect helpers, bake options, and future stubs) for later implementation

## Testing
- pip install -e .
- ruff check .
- black --check .
- n2d version
- n2d inspect /tmp/min.obj --inspect-json /tmp/min.json

------
https://chatgpt.com/codex/tasks/task_e_68c913a1740c832696fc3bc4584f317a