### PR TITLE
Implement UV rasterization sidecars and deterministic bake tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.venv/
+__pycache__/
+*.pyc
+normal2disp.egg-info/

--- a/normal2disp/__init__.py
+++ b/normal2disp/__init__.py
@@ -1,0 +1,8 @@
+"""Top-level package for normal2disp."""
+
+from . import n2d as _n2d
+
+__all__ = ["n2d", "__version__", "get_version"]
+
+__version__ = _n2d.__version__
+get_version = _n2d.get_version

--- a/normal2disp/n2d/__init__.py
+++ b/normal2disp/n2d/__init__.py
@@ -1,0 +1,17 @@
+"""Core package metadata and helpers for normal2disp."""
+
+from __future__ import annotations
+
+from importlib import metadata
+
+__all__ = ["__version__", "get_version"]
+
+__version__ = "0.1.0"
+
+
+def get_version() -> str:
+    """Return the installed package version."""
+    try:
+        return metadata.version("normal2disp")
+    except metadata.PackageNotFoundError:
+        return __version__

--- a/normal2disp/n2d/bake.py
+++ b/normal2disp/n2d/bake.py
@@ -1,0 +1,227 @@
+"""Displacement bake orchestration (stub for future phases)."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Dict, Iterable, List, Mapping, Optional, Tuple
+from typing import Literal
+
+from .core import TextureAssignmentError
+from .image_utils import expand_udim_pattern, load_texture_info, write_exr_channels
+from .inspect import MeshInfo, UVSetInfo
+from .uv_raster import TileRasterResult, rasterize_uv_charts
+
+NormalizationMode = Literal["auto", "xyz", "xy", "none"]
+LoaderMode = Literal["auto", "pyassimp", "blender"]
+
+
+@dataclass
+class BakeOptions:
+    """Options that configure the displacement baking process."""
+
+    uv_set: Optional[str] = None
+    y_is_down: bool = False
+    normalization: NormalizationMode = "auto"
+    max_slope: float = 10.0
+    amplitude: float = 1.0
+    cg_tol: float = 1e-6
+    cg_maxiter: int = 10000
+    deterministic: bool = False
+    processes: Optional[int] = None
+    loader: LoaderMode = "auto"
+    export_sidecars: bool = False
+    on_progress: Optional[Callable[[str, float], None]] = None
+
+
+def bake(
+    mesh_path: Path,
+    normal_pattern: str,
+    output_pattern: str,
+    options: Optional[BakeOptions] = None,
+) -> Tuple[List[Path], List[str], List[Path]]:
+    """Placeholder for the future baking pipeline implementation."""
+
+    raise NotImplementedError("Bake pipeline will be implemented in a later phase.")
+
+
+def resolve_material_textures(
+    mesh_info: MeshInfo,
+    uv_set: str,
+    default_pattern: Optional[str],
+    overrides: Mapping[str, str],
+) -> Dict[int, Dict[str, object]]:
+    """Resolve texture assignments per material and expand UDIM tiles."""
+
+    if uv_set not in mesh_info.uv_sets:
+        available = ", ".join(sorted(mesh_info.uv_sets)) or "<none>"
+        raise TextureAssignmentError(f"UV set '{uv_set}' not found. Available sets: {available}")
+
+    uv_info = mesh_info.uv_sets[uv_set]
+    materials = dict(mesh_info.materials)
+
+    normalized_overrides: Dict[int, str] = {}
+    for key, pattern in overrides.items():
+        material_id = _resolve_material_key(materials, key)
+        if material_id is None:
+            raise TextureAssignmentError(f"Unknown material override target '{key}'")
+        normalized_overrides[material_id] = pattern
+
+    assignments: Dict[int, Dict[str, object]] = {}
+
+    for material_id, name in materials.items():
+        pattern = normalized_overrides.get(material_id, default_pattern)
+
+        required_tiles = set(
+            int(tile) for tile in uv_info.per_material_udims.get(material_id, set())
+        )
+
+        tile_map: Dict[int, Path] = {}
+        if pattern:
+            tile_map = expand_udim_pattern(pattern)
+        elif required_tiles:
+            raise TextureAssignmentError(
+                f"Material {material_id} ('{name}') requires textures but no pattern was provided"
+            )
+
+        found_tiles = set(tile_map.keys())
+        missing_tiles = required_tiles - found_tiles
+
+        assignments[material_id] = {
+            "material_name": name,
+            "pattern": pattern,
+            "tiles_found": found_tiles,
+            "tiles_required": required_tiles,
+            "missing_tiles": missing_tiles,
+            "tile_paths": tile_map,
+        }
+
+    return assignments
+
+
+def _resolve_material_key(materials: Mapping[int, str], key: str) -> Optional[int]:
+    try:
+        index = int(key)
+    except ValueError:
+        candidates = [
+            material_id for material_id, name in materials.items() if name.lower() == key.lower()
+        ]
+        if len(candidates) == 1:
+            return candidates[0]
+        if len(candidates) > 1:
+            raise TextureAssignmentError(f"Material name '{key}' is ambiguous")
+        return None
+    else:
+        return index if index in materials else None
+
+
+def export_sidecars(
+    mesh_info: MeshInfo,
+    uv_set: str,
+    assignments: Mapping[int, Mapping[str, object]],
+    *,
+    deterministic: bool = False,
+    y_is_down: bool = False,
+) -> List[Path]:
+    """Rasterise charts and write sidecar assets for ``uv_set``."""
+
+    if uv_set not in mesh_info.uv_sets:
+        available = ", ".join(sorted(mesh_info.uv_sets)) or "<none>"
+        raise TextureAssignmentError(f"UV set '{uv_set}' not found. Available sets: {available}")
+
+    uv_info = mesh_info.uv_sets[uv_set]
+    tile_resolutions = _collect_tile_resolutions(assignments)
+    if not tile_resolutions:
+        raise TextureAssignmentError(
+            "Cannot export sidecars because no texture tiles were resolved."
+        )
+
+    raster_results = rasterize_uv_charts(uv_info, tile_resolutions, deterministic=deterministic)
+
+    output_dir = _default_sidecar_directory(mesh_info.path)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    y_channel = "-Y" if y_is_down else "+Y"
+    sidecar_paths: List[Path] = []
+
+    for result in raster_results:
+        base_name = f"{uv_set}_{result.tile}"
+
+        chart_path = output_dir / f"{base_name}_chart_id.exr"
+        write_exr_channels(chart_path, {"chart_id": result.chart_mask})
+        sidecar_paths.append(chart_path)
+
+        boundary_path = output_dir / f"{base_name}_boundary.exr"
+        write_exr_channels(boundary_path, {"boundary": result.boundary_mask})
+        sidecar_paths.append(boundary_path)
+
+        chart_table_path = output_dir / f"{base_name}_chart_table.json"
+        table = _build_chart_table_payload(result, uv_info, y_channel)
+        with chart_table_path.open("w", encoding="utf-8") as handle:
+            json.dump(table, handle, indent=2)
+            handle.write("\n")
+        sidecar_paths.append(chart_table_path)
+
+    return sidecar_paths
+
+
+def _collect_tile_resolutions(
+    assignments: Mapping[int, Mapping[str, object]]
+) -> Dict[int, Tuple[int, int]]:
+    tile_sizes: Dict[int, Tuple[int, int]] = {}
+    tile_sources: Dict[int, List[Tuple[int, Path, Tuple[int, int]]]] = {}
+
+    for material_id, data in assignments.items():
+        tile_paths: Mapping[int, Path] = data.get("tile_paths", {})  # type: ignore[assignment]
+        for tile, path in tile_paths.items():
+            info = load_texture_info(Path(path))
+            resolution = (info.height, info.width)
+            existing = tile_sizes.get(tile)
+            tile_sources.setdefault(tile, []).append((material_id, Path(path), resolution))
+
+            if existing is None:
+                tile_sizes[tile] = resolution
+            elif existing != resolution:
+                message = _format_resolution_conflict(tile, tile_sources[tile])
+                raise TextureAssignmentError(message)
+
+    return tile_sizes
+
+
+def _format_resolution_conflict(
+    tile: int, sources: Iterable[Tuple[int, Path, Tuple[int, int]]]
+) -> str:
+    parts = []
+    for material_id, path, (height, width) in sources:
+        parts.append(f"material {material_id} → {path} ({width}×{height})")
+    joined = "; ".join(parts)
+    return f"UDIM {tile} has mixed resolutions: {joined}"
+
+
+def _default_sidecar_directory(mesh_path: Path) -> Path:
+    return mesh_path.parent / f"{mesh_path.stem}_sidecars"
+
+
+def _build_chart_table_payload(
+    result: TileRasterResult, uv_info: UVSetInfo, y_channel: str
+) -> Dict[str, object]:
+    charts_payload = []
+    for entry in sorted(result.charts, key=lambda chart: chart.local_id):
+        charts_payload.append(
+            {
+                "id": int(entry.local_id),
+                "flip_u": bool(entry.flip_u),
+                "flip_v": bool(entry.flip_v),
+                "pixel_count": int(entry.pixel_count),
+                "bbox_uv": [float(value) for value in entry.bbox_uv],
+                "bbox_px": [int(value) for value in entry.bbox_px],
+            }
+        )
+
+    return {
+        "tile": int(result.tile),
+        "uv_set": uv_info.name,
+        "charts": charts_payload,
+        "y_channel": y_channel,
+    }

--- a/normal2disp/n2d/cli.py
+++ b/normal2disp/n2d/cli.py
@@ -1,0 +1,342 @@
+"""Command line interface for the ``n2d`` tool."""
+
+from __future__ import annotations
+
+import json
+import logging
+from importlib import import_module
+from pathlib import Path
+from typing import Any, Dict, List, Tuple
+
+import click
+from rich.console import Console
+from rich.table import Table
+
+from . import get_version
+from .core import ImageIOError, MeshLoadError, TextureAssignmentError, UDIMError
+from .bake import BakeOptions, export_sidecars, resolve_material_textures
+from .inspect import _ensure_pyassimp_dependencies, inspect_mesh, run_inspect
+
+__all__ = ["main"]
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def _configure_logging(verbose: bool) -> None:
+    level = logging.DEBUG if verbose else logging.INFO
+    logging.basicConfig(level=level, format="%(levelname)s:%(name)s:%(message)s")
+    _LOGGER.debug("Logging configured (level=%s)", logging.getLevelName(level))
+
+
+def _probe_module(module_name: str) -> Tuple[bool, str | None]:
+    if module_name in {"pyassimp", "OpenImageIO"}:
+        try:
+            _ensure_pyassimp_dependencies()
+        except MeshLoadError:
+            # Dependencies missing; fall back to standard import attempt.
+            pass
+
+    try:
+        module = import_module(module_name)
+    except Exception as exc:  # pragma: no cover - import failure depends on environment
+        return False, str(exc)
+
+    version = getattr(module, "__version__", None)
+    if module_name == "OpenImageIO" and version is None:
+        version = getattr(module, "VERSION", None)
+        if isinstance(version, int):
+            version = str(version)
+    detail = f"v{version}" if version else None
+    return True, detail
+
+
+def _parse_material_override(value: str) -> Tuple[str, str]:
+    if "=" not in value:
+        raise click.BadParameter(
+            "Material overrides must use the form NameOrIndex=pattern", param="--mat-normal"
+        )
+
+    key, pattern = value.split("=", 1)
+    key = key.strip()
+    pattern = pattern.strip()
+    if not key or not pattern:
+        raise click.BadParameter(
+            "Material overrides must use the form NameOrIndex=pattern", param="--mat-normal"
+        )
+
+    return key, pattern
+
+
+@click.group()
+@click.option("--verbose", is_flag=True, help="Enable verbose logging output")
+@click.pass_context
+def main(ctx: click.Context, verbose: bool) -> None:
+    """Entrypoint for the ``n2d`` command."""
+
+    _configure_logging(verbose)
+    ctx.ensure_object(dict)
+    ctx.obj["console"] = Console()
+    ctx.obj["verbose"] = bool(verbose)
+
+
+@main.command()
+def version() -> None:
+    """Show package version and capability probes."""
+
+    pkg_version = get_version()
+    click.echo(f"normal2disp {pkg_version}")
+
+    for module_name in ("OpenImageIO", "pyassimp"):
+        available, detail = _probe_module(module_name)
+        status = "yes" if available else "no"
+        if detail:
+            status = f"{status} ({detail})"
+        click.echo(f"{module_name}: {status}")
+
+
+@main.command(name="inspect")
+@click.argument("mesh_path", type=click.Path(path_type=Path, exists=True, dir_okay=False))
+@click.option(
+    "--inspect-json",
+    type=click.Path(path_type=Path),
+    help="Write the inspection report to this JSON file.",
+)
+@click.option(
+    "--loader",
+    type=click.Choice(["auto", "pyassimp"], case_sensitive=False),
+    default="auto",
+    show_default=True,
+    help="Mesh loader backend",
+)
+@click.pass_context
+def inspect_command(
+    ctx: click.Context,
+    mesh_path: Path,
+    inspect_json: Path | None,
+    loader: str,
+) -> None:
+    """Inspect mesh UV sets and UDIM coverage."""
+
+    try:
+        report = run_inspect(mesh_path, loader=loader)
+    except MeshLoadError as exc:
+        raise click.ClickException(str(exc)) from exc
+    except Exception as exc:  # pragma: no cover - safeguard
+        raise click.ClickException(f"Failed to inspect mesh: {exc}") from exc
+
+    ctx_obj: Dict[str, Any] = ctx.obj if isinstance(ctx.obj, dict) else {}
+    console = ctx_obj.get("console")
+    if not isinstance(console, Console):
+        console = Console()
+    table = Table(title=str(mesh_path))
+    table.add_column("UV Set")
+    table.add_column("Charts", justify="right")
+    table.add_column("UDIMs")
+
+    uv_sets: Dict[str, Dict[str, Any]] = dict(report.get("uv_sets", {}))
+    if not uv_sets:
+        table.add_row("—", "0", "—")
+    else:
+        for uv_name in sorted(uv_sets):
+            uv_set = uv_sets[uv_name]
+            udims = uv_set.get("udims", [])
+            udim_text = ", ".join(str(tile) for tile in udims) if udims else "—"
+            table.add_row(uv_name, str(uv_set.get("chart_count", 0)), udim_text)
+
+    console.print(table)
+
+    verbose_enabled = bool(ctx_obj.get("verbose"))
+    if verbose_enabled and uv_sets:
+        chart_table = Table(title="Chart Flags")
+        chart_table.add_column("UV Set")
+        chart_table.add_column("Chart", justify="right")
+        chart_table.add_column("Faces", justify="right")
+        chart_table.add_column("Mirrored")
+        chart_table.add_column("Flip U")
+        chart_table.add_column("Flip V")
+
+        material_table = Table(title="Chart Materials")
+        material_table.add_column("UV Set")
+        material_table.add_column("Chart", justify="right")
+        material_table.add_column("Material ID", justify="right")
+        material_table.add_column("Material Name")
+
+        row_count = 0
+        material_row_count = 0
+        for uv_name in sorted(uv_sets):
+            for chart in uv_sets[uv_name].get("charts", []):
+                row_count += 1
+                chart_table.add_row(
+                    uv_name,
+                    str(chart.get("id", "")),
+                    str(chart.get("face_count", "")),
+                    "yes" if chart.get("mirrored") else "no",
+                    "yes" if chart.get("flip_u") else "no",
+                    "yes" if chart.get("flip_v") else "no",
+                )
+                material_row_count += 1
+                material_table.add_row(
+                    uv_name,
+                    str(chart.get("id", "")),
+                    str(chart.get("material_id", "")),
+                    chart.get("material_name", ""),
+                )
+
+        if row_count:
+            console.print(chart_table)
+        if material_row_count:
+            console.print(material_table)
+
+    if inspect_json is not None:
+        inspect_json.parent.mkdir(parents=True, exist_ok=True)
+        with inspect_json.open("w", encoding="utf-8") as handle:
+            json.dump(report, handle, indent=2)
+            handle.write("\n")
+        console.print(f"[green]Wrote inspection report to {inspect_json}[/green]")
+
+
+@main.command(name="bake")
+@click.argument("mesh_path", type=click.Path(path_type=Path, exists=True, dir_okay=False))
+@click.option("--normal", "default_normal", type=str, help="Default normal map pattern")
+@click.option(
+    "--mat-normal",
+    "material_normals",
+    multiple=True,
+    help="Material override in the form NameOrIndex=pattern",
+)
+@click.option("--uv-set", "uv_set", type=str, help="UV set to use (defaults to first)")
+@click.option("--y-is-down", is_flag=True, help="Treat +Y normals as pointing down")
+@click.option(
+    "--normalization",
+    type=click.Choice(["auto", "xyz", "xy", "none"], case_sensitive=False),
+    default="auto",
+    show_default=True,
+    help="Normal map normalization policy",
+)
+@click.option("--validate-only", is_flag=True, help="Only validate texture assignments")
+@click.option(
+    "--export-sidecars", "export_sidecars_flag", is_flag=True, help="Write chart masks and tables"
+)
+@click.option("--deterministic", is_flag=True, help="Force deterministic processing order")
+@click.option(
+    "--inspect-json",
+    type=click.Path(path_type=Path),
+    help="Write validation report to this JSON file.",
+)
+@click.option(
+    "--loader",
+    type=click.Choice(["auto", "pyassimp"], case_sensitive=False),
+    default="auto",
+    show_default=True,
+    help="Mesh loader backend",
+)
+@click.pass_context
+def bake_command(
+    ctx: click.Context,
+    mesh_path: Path,
+    default_normal: str | None,
+    material_normals: Tuple[str, ...],
+    uv_set: str | None,
+    y_is_down: bool,
+    normalization: str,
+    validate_only: bool,
+    export_sidecars_flag: bool,
+    deterministic: bool,
+    inspect_json: Path | None,
+    loader: str,
+) -> None:
+    """Validate and orchestrate displacement baking."""
+
+    overrides: Dict[str, str] = {}
+    for entry in material_normals:
+        key, pattern = _parse_material_override(entry)
+        overrides[key] = pattern
+
+    try:
+        mesh_info = inspect_mesh(mesh_path, loader=loader)
+    except MeshLoadError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+    uv_set_name = uv_set
+    if uv_set_name is None:
+        if mesh_info.uv_sets:
+            uv_set_name = sorted(mesh_info.uv_sets)[0]
+        else:
+            raise click.ClickException("Mesh does not contain any UV sets")
+
+    options = BakeOptions(
+        uv_set=uv_set_name,
+        y_is_down=y_is_down,
+        normalization=normalization,
+        loader=loader,
+        export_sidecars=export_sidecars_flag,
+        deterministic=deterministic,
+    )
+    ctx.obj = ctx.obj or {}
+    if isinstance(ctx.obj, dict):
+        ctx.obj["bake_options"] = options
+
+    if not validate_only:
+        raise click.ClickException("Only --validate-only mode is supported in this phase")
+
+    try:
+        assignments = resolve_material_textures(mesh_info, uv_set_name, default_normal, overrides)
+    except (TextureAssignmentError, ImageIOError, UDIMError) as exc:
+        raise click.ClickException(str(exc)) from exc
+
+    materials_report = []
+    missing_materials: Dict[int, Dict[str, object]] = {}
+    for material_id, data in sorted(assignments.items()):
+        tiles_found = sorted(int(tile) for tile in data["tiles_found"])
+        tiles_required = sorted(int(tile) for tile in data["tiles_required"])
+        missing_tiles = sorted(int(tile) for tile in data["missing_tiles"])
+        if missing_tiles:
+            missing_materials[material_id] = data
+
+        materials_report.append(
+            {
+                "id": material_id,
+                "name": data["material_name"],
+                "pattern": data["pattern"],
+                "tiles_found": tiles_found,
+                "tiles_required": tiles_required,
+                "missing_tiles": missing_tiles,
+                "tile_paths": {str(tile): str(path) for tile, path in data["tile_paths"].items()},
+            }
+        )
+
+    sidecar_paths: List[Path] = []
+    if export_sidecars_flag and not missing_materials:
+        try:
+            sidecar_paths = export_sidecars(
+                mesh_info,
+                uv_set_name,
+                assignments,
+                deterministic=deterministic,
+                y_is_down=y_is_down,
+            )
+        except (TextureAssignmentError, ImageIOError) as exc:
+            raise click.ClickException(str(exc)) from exc
+
+    report = {"mesh": str(mesh_path), "uv_set": uv_set_name, "materials": materials_report}
+    if sidecar_paths:
+        report["sidecars"] = [str(path) for path in sidecar_paths]
+
+    click.echo(json.dumps(report, indent=2))
+
+    if inspect_json is not None:
+        inspect_json.parent.mkdir(parents=True, exist_ok=True)
+        with inspect_json.open("w", encoding="utf-8") as handle:
+            json.dump(report, handle, indent=2)
+            handle.write("\n")
+
+    if missing_materials:
+        summary = ", ".join(
+            f"{material_id} ({assignments[material_id]['material_name']}): {sorted(assignments[material_id]['missing_tiles'])}"
+            for material_id in sorted(missing_materials)
+        )
+        raise click.ClickException(f"Missing UDIM tiles detected: {summary}")
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    main()

--- a/normal2disp/n2d/core.py
+++ b/normal2disp/n2d/core.py
@@ -1,0 +1,31 @@
+"""Core types and exceptions for normal2disp."""
+
+from __future__ import annotations
+
+__all__ = [
+    "N2DError",
+    "MeshLoadError",
+    "ImageIOError",
+    "UDIMError",
+    "TextureAssignmentError",
+]
+
+
+class N2DError(Exception):
+    """Base exception for normal2disp errors."""
+
+
+class MeshLoadError(N2DError):
+    """Raised when a mesh cannot be loaded."""
+
+
+class ImageIOError(N2DError):
+    """Raised when image input/output fails."""
+
+
+class UDIMError(N2DError):
+    """Raised when UDIM expansion or validation fails."""
+
+
+class TextureAssignmentError(N2DError):
+    """Raised when CLI texture assignment arguments are invalid."""

--- a/normal2disp/n2d/image_utils.py
+++ b/normal2disp/n2d/image_utils.py
@@ -1,0 +1,208 @@
+"""Image I/O helpers (implemented in later phases)."""
+
+from __future__ import annotations
+
+import glob
+import logging
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Mapping, Optional
+
+import numpy as np
+
+from .core import ImageIOError, UDIMError
+
+__all__ = [
+    "TextureInfo",
+    "load_texture_info",
+    "expand_udim_pattern",
+    "write_exr_channels",
+]
+
+_LOGGER = logging.getLogger(__name__)
+
+_UDIM_TOKEN = "<UDIM>"
+_PRINTF_TOKEN = "%04d"
+
+
+@dataclass(frozen=True)
+class TextureInfo:
+    """Metadata about a texture file discovered via OpenImageIO."""
+
+    path: Path
+    width: int
+    height: int
+    channels: int
+    pixel_type: str
+    colorspace: Optional[str]
+
+
+def load_texture_info(path: Path) -> TextureInfo:
+    """Load image metadata using OpenImageIO."""
+
+    resolved = path.expanduser()
+
+    _ensure_system_site_packages()
+    try:
+        import OpenImageIO as oiio
+    except ImportError as exc:  # pragma: no cover - environment specific
+        raise ImageIOError("OpenImageIO is required for texture loading in this phase") from exc
+
+    input_handle = oiio.ImageInput.open(str(resolved))
+    if input_handle is None:  # pragma: no cover - depends on asset
+        raise ImageIOError(f"Failed to open image '{resolved}': {oiio.geterror()}")
+
+    try:
+        spec = input_handle.spec()
+        width = int(spec.width)
+        height = int(spec.height)
+        channels = int(spec.nchannels)
+        pixel_type = str(spec.format)
+
+        colorspace = None
+        for attribute_name in ("oiio:ColorSpace", "oiio:colorspace"):
+            value = spec.getattribute(attribute_name)
+            if value:
+                colorspace = str(value)
+                break
+
+        if colorspace and colorspace.lower() == "srgb":
+            _LOGGER.warning(
+                "Texture '%s' reports sRGB colorspace; treating as linear normal map.", resolved
+            )
+
+        return TextureInfo(
+            path=resolved,
+            width=width,
+            height=height,
+            channels=channels,
+            pixel_type=pixel_type,
+            colorspace=colorspace,
+        )
+    finally:
+        input_handle.close()
+
+
+def expand_udim_pattern(pattern: str) -> Dict[int, Path]:
+    """Expand a UDIM filename pattern into discovered tiles on disk."""
+
+    normalized = str(Path(pattern).expanduser())
+    placeholder = _detect_placeholder(normalized)
+
+    if placeholder is None:
+        path = Path(normalized)
+        if not path.exists():
+            return {}
+        load_texture_info(path)
+        tile = _extract_tile_from_path(path)
+        if tile is None:
+            tile = 1001
+        return {int(tile): path}
+
+    glob_pattern = _pattern_to_glob(normalized, placeholder)
+    regex = _pattern_to_regex(normalized, placeholder)
+
+    matches: Dict[int, Path] = {}
+    for candidate in sorted(glob.glob(glob_pattern)):
+        match = regex.fullmatch(candidate)
+        if not match:
+            continue
+        tile_value = int(match.group("udim"))
+        if tile_value in matches:
+            raise UDIMError(
+                f"Multiple textures found for UDIM {tile_value} matching pattern '{pattern}'"
+            )
+        matches[tile_value] = Path(candidate)
+        load_texture_info(Path(candidate))
+
+    return dict(sorted(matches.items()))
+
+
+def _detect_placeholder(pattern: str) -> Optional[str]:
+    if _UDIM_TOKEN in pattern:
+        return _UDIM_TOKEN
+    if _PRINTF_TOKEN in pattern:
+        return _PRINTF_TOKEN
+    return None
+
+
+def _pattern_to_glob(pattern: str, placeholder: str) -> str:
+    replacement = "[0-9][0-9][0-9][0-9]"
+    return pattern.replace(placeholder, replacement)
+
+
+def _pattern_to_regex(pattern: str, placeholder: str) -> re.Pattern[str]:
+    escaped = re.escape(pattern)
+    token = re.escape(placeholder)
+    pattern_regex = escaped.replace(token, r"(?P<udim>[0-9]{4})")
+    return re.compile(pattern_regex)
+
+
+def _extract_tile_from_path(path: Path) -> Optional[int]:
+    match = re.search(r"(1\d{3})", path.name)
+    if match:
+        try:
+            return int(match.group(1))
+        except ValueError:  # pragma: no cover - defensive
+            return None
+    return None
+
+
+def _ensure_system_site_packages() -> None:
+    system_site = Path("/usr/lib/python3/dist-packages")
+    system_site_str = str(system_site)
+    if system_site.exists() and system_site_str not in sys.path:
+        sys.path.append(system_site_str)
+
+
+def write_exr_channels(path: Path, channels: Mapping[str, np.ndarray]) -> None:
+    """Write an EXR file with the given ``channels`` using OpenImageIO."""
+
+    if not channels:
+        raise ImageIOError("No channels provided for EXR output")
+
+    arrays = []
+    channel_names: list[str] = []
+
+    for name, data in channels.items():
+        array = np.asarray(data, dtype=np.float32)
+        if array.ndim == 2:
+            pass
+        elif array.ndim == 3 and array.shape[2] == 1:
+            array = array[:, :, 0]
+        else:
+            raise ImageIOError(f"Channel '{name}' must be 2D; received shape {array.shape}")
+
+        arrays.append(array)
+        channel_names.append(str(name))
+
+    height, width = arrays[0].shape
+    for array in arrays[1:]:
+        if array.shape != (height, width):
+            raise ImageIOError("All channels must share the same resolution")
+
+    stacked = np.stack(arrays, axis=2)
+
+    _ensure_system_site_packages()
+    try:
+        import OpenImageIO as oiio
+    except ImportError as exc:  # pragma: no cover - environment specific
+        raise ImageIOError("OpenImageIO is required for writing EXR files") from exc
+
+    output = oiio.ImageOutput.create(str(path))
+    if output is None:  # pragma: no cover - depends on oiio availability
+        raise ImageIOError(f"Failed to create image writer for '{path}': {oiio.geterror()}")
+
+    try:
+        spec = oiio.ImageSpec(width, height, len(channel_names), oiio.FLOAT)
+        spec.channelnames = channel_names
+        if not output.open(str(path), spec):
+            raise ImageIOError(f"Failed to open '{path}' for writing: {output.geterror()}")
+
+        data = np.ascontiguousarray(stacked, dtype=np.float32)
+        if not output.write_image(data):
+            raise ImageIOError(f"Failed to write image '{path}': {output.geterror()}")
+    finally:
+        output.close()

--- a/normal2disp/n2d/inspect.py
+++ b/normal2disp/n2d/inspect.py
@@ -1,0 +1,657 @@
+"""Mesh inspection helpers for the ``n2d inspect`` CLI command."""
+
+from __future__ import annotations
+
+import importlib
+import logging
+import sys
+from pathlib import Path
+from collections import Counter
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Mapping, Sequence, Set, Tuple
+
+import numpy as np
+
+from .core import MeshLoadError
+from .mesh_utils import compute_triangle_tangent_frames
+
+__all__ = [
+    "run_inspect",
+    "inspect_mesh",
+    "MeshInfo",
+    "UVSetInfo",
+    "ChartInfo",
+    "UVSetMeshData",
+]
+
+_LOGGER = logging.getLogger(__name__)
+
+_UV_EPSILON = 1e-5
+_VECTOR_EPSILON = 1e-6
+
+
+@dataclass(frozen=True)
+class ChartInfo:
+    """Information about a single UV chart."""
+
+    id: int
+    face_count: int
+    bbox_uv: Tuple[float, float, float, float]
+    mirrored: bool
+    flip_u: bool
+    flip_v: bool
+    material_id: int
+    material_name: str
+    udims: Set[int] = field(default_factory=set)
+
+
+@dataclass(frozen=True, eq=False)
+class UVSetMeshData:
+    """Raw mesh data for a UV set used during rasterisation."""
+
+    faces: np.ndarray
+    uv: np.ndarray
+    face_materials: np.ndarray
+    face_chart_ids: np.ndarray
+    chart_faces: Mapping[int, np.ndarray]
+    face_udims: Tuple[Set[int], ...]
+
+
+@dataclass(frozen=True, eq=False)
+class UVSetInfo:
+    """Aggregated information about a UV set."""
+
+    name: str
+    charts: List[ChartInfo]
+    udims: Set[int]
+    per_material_udims: Mapping[int, Set[int]]
+    mesh_data: UVSetMeshData
+
+
+@dataclass(frozen=True, eq=False)
+class MeshInfo:
+    """Summary of mesh UV information used by inspection and baking."""
+
+    path: Path
+    materials: Mapping[int, str]
+    uv_sets: Mapping[str, UVSetInfo]
+
+
+def inspect_mesh(mesh_path: Path, loader: str = "auto") -> MeshInfo:
+    """Load ``mesh_path`` and compute inspection metadata."""
+
+    resolved_path = mesh_path.expanduser().resolve()
+    loader_choice = loader.lower()
+    if loader_choice not in {"auto", "pyassimp"}:
+        raise MeshLoadError(
+            f"Unsupported loader '{loader}'. Only 'auto' and 'pyassimp' are available in this phase."
+        )
+
+    _ensure_pyassimp_dependencies()
+
+    try:
+        from pyassimp import errors as pyassimp_errors
+        from pyassimp import load as assimp_load
+    except ImportError as exc:  # pragma: no cover - handled in runtime
+        raise MeshLoadError("pyassimp is required for mesh inspection") from exc
+
+    try:
+        with assimp_load(str(resolved_path)) as scene:
+            if scene is None or not scene.meshes:
+                raise MeshLoadError(f"Mesh '{resolved_path}' does not contain any geometry")
+
+            materials = _extract_materials(scene)
+            vertices, faces, uv_sets, face_materials = _collect_scene_geometry(scene)
+
+            uv_infos: Dict[str, UVSetInfo] = {}
+            for name, uv_coords in uv_sets.items():
+                uv_infos[name] = _analyse_uv_set(
+                    vertices,
+                    faces,
+                    uv_coords,
+                    face_materials,
+                    materials,
+                    uv_set_name=name,
+                )
+
+            mesh_info = MeshInfo(path=resolved_path, materials=materials, uv_sets=uv_infos)
+            _LOGGER.debug("Mesh info generated: %s", mesh_info)
+            return mesh_info
+    except pyassimp_errors.AssimpError as exc:  # pragma: no cover - depends on asset
+        raise MeshLoadError(f"Failed to load mesh '{resolved_path}': {exc}") from exc
+
+
+def run_inspect(mesh_path: Path, loader: str = "auto") -> Dict[str, Any]:
+    """Inspect ``mesh_path`` and return a serialisable report."""
+
+    mesh_info = inspect_mesh(mesh_path, loader=loader)
+    report = _mesh_info_to_report(mesh_info)
+    _LOGGER.debug("Inspection report generated: %s", report)
+    return report
+
+
+def _mesh_info_to_report(mesh_info: MeshInfo) -> Dict[str, Any]:
+    materials = [
+        {"id": int(material_id), "name": name}
+        for material_id, name in sorted(mesh_info.materials.items())
+    ]
+
+    uv_sets: Dict[str, Dict[str, Any]] = {}
+    for uv_name, uv_info in sorted(mesh_info.uv_sets.items()):
+        charts = [
+            {
+                "id": chart.id,
+                "face_count": chart.face_count,
+                "bbox_uv": list(chart.bbox_uv),
+                "mirrored": chart.mirrored,
+                "flip_u": chart.flip_u,
+                "flip_v": chart.flip_v,
+                "material_id": chart.material_id,
+                "material_name": chart.material_name,
+            }
+            for chart in uv_info.charts
+        ]
+
+        uv_sets[uv_name] = {
+            "chart_count": len(charts),
+            "udims": sorted(int(tile) for tile in uv_info.udims),
+            "charts": charts,
+        }
+
+    return {"path": str(mesh_info.path), "materials": materials, "uv_sets": uv_sets}
+
+
+def _collect_scene_geometry(
+    scene: Any,
+) -> Tuple[np.ndarray, np.ndarray, Dict[str, np.ndarray], np.ndarray]:
+    vertex_parts: List[np.ndarray] = []
+    face_parts: List[np.ndarray] = []
+    face_material_parts: List[np.ndarray] = []
+    uv_segments: Dict[str, List[Tuple[int, np.ndarray]]] = {}
+
+    vertex_offset = 0
+    for mesh in getattr(scene, "meshes", []):
+        mesh_vertices = np.asarray(getattr(mesh, "vertices", ()), dtype=np.float64)
+        if mesh_vertices.ndim != 2 or mesh_vertices.shape[0] == 0 or mesh_vertices.shape[1] < 3:
+            continue
+
+        faces_seq = getattr(mesh, "faces", ())
+        faces = np.array(
+            [np.asarray(face, dtype=np.int64) for face in faces_seq if len(face) == 3],
+            dtype=np.int64,
+        )
+        if faces.size == 0:
+            continue
+
+        vertex_count = mesh_vertices.shape[0]
+        vertex_parts.append(mesh_vertices[:, :3])
+        face_parts.append(faces + vertex_offset)
+
+        material_index = int(getattr(mesh, "materialindex", 0) or 0)
+        face_material_parts.append(np.full(faces.shape[0], material_index, dtype=np.int32))
+
+        coords_sequences = getattr(mesh, "texturecoords", [])
+        component_counts = getattr(mesh, "numuvcomponents", [])
+        for uv_index, coords in enumerate(coords_sequences):
+            if coords is None:
+                continue
+            components = int(component_counts[uv_index]) if uv_index < len(component_counts) else 0
+            if components < 2:
+                continue
+            uv_array = np.asarray(coords, dtype=np.float64)
+            if uv_array.ndim != 2 or uv_array.shape[0] != vertex_count:
+                continue
+            uv_segments.setdefault(f"UV{uv_index}", []).append((vertex_offset, uv_array[:, :2]))
+
+        vertex_offset += vertex_count
+
+    if not vertex_parts or not face_parts:
+        raise MeshLoadError("Mesh does not contain any triangular faces")
+
+    vertices = np.vstack(vertex_parts)
+    faces = np.vstack(face_parts)
+    face_materials = np.concatenate(face_material_parts)
+
+    total_vertices = vertices.shape[0]
+    uv_sets: Dict[str, np.ndarray] = {}
+    for name, segments in uv_segments.items():
+        combined = np.full((total_vertices, 2), np.nan, dtype=np.float64)
+        for offset, uv_array in segments:
+            count = uv_array.shape[0]
+            combined[offset : offset + count] = uv_array
+        uv_sets[name] = combined
+
+    return vertices, faces, uv_sets, face_materials
+
+
+def _extract_materials(scene: Any) -> Dict[int, str]:
+    materials: Dict[int, str] = {}
+
+    for index, material in enumerate(getattr(scene, "materials", [])):
+        name: str | None = None
+        prop_source = getattr(material, "properties", None)
+        if prop_source is not None:
+            try:
+                for key, value in prop_source.items():
+                    if key == "name" and isinstance(value, str):
+                        candidate = value.strip()
+                        if candidate:
+                            name = candidate
+                            break
+            except AttributeError:
+                pass
+
+        if name is None:
+            props = None
+            if hasattr(material, "properties") and hasattr(material, "contents"):
+                try:
+                    props = list(material.properties)
+                except TypeError:
+                    props = None
+            if props is None and hasattr(material, "contents"):
+                props = getattr(material.contents, "mProperties", None)
+
+            if props is None:
+                props = []
+
+            for prop in props:
+                key = getattr(prop, "key", "")
+                data = getattr(prop, "data", b"")
+
+                if hasattr(prop, "contents"):
+                    key_bytes = getattr(prop.contents.mKey, "data", b"")
+                    if isinstance(key_bytes, bytes):
+                        key = key_bytes.decode("utf-8", errors="ignore")
+                    data = bytes(prop.contents.mData[: prop.contents.mDataLength])
+                else:
+                    if isinstance(key, bytes):
+                        key = key.decode("utf-8", errors="ignore")
+                    if isinstance(data, bytes):
+                        data = data
+
+                if key not in {"?mat.name", "name"}:
+                    continue
+
+                decoded = _decode_material_name_bytes(data)
+                if decoded:
+                    name = decoded
+                    break
+
+        materials[index] = name or f"Material{index}"
+
+    if not materials:
+        materials[0] = "Material0"
+
+    return materials
+
+
+def _decode_material_name_bytes(data: Any) -> str | None:
+    if isinstance(data, bytes):
+        if len(data) >= 4:
+            length = int.from_bytes(data[:4], "little", signed=False)
+            if length > 0:
+                name_bytes = data[4 : 4 + length]
+                return name_bytes.decode("utf-8", errors="ignore").strip()
+        decoded = data.decode("utf-8", errors="ignore").replace("\x00", "").strip()
+        return decoded or None
+    if isinstance(data, str):
+        decoded = data.replace("\x00", "").strip()
+        return decoded or None
+    return None
+
+
+def _analyse_uv_set(
+    vertices: np.ndarray,
+    faces: np.ndarray,
+    uv_coords: np.ndarray,
+    face_materials: np.ndarray,
+    materials: Mapping[int, str],
+    *,
+    uv_set_name: str,
+) -> UVSetInfo:
+    if uv_coords.shape[0] != vertices.shape[0]:
+        raise MeshLoadError(
+            f"UV set '{uv_set_name}' has {uv_coords.shape[0]} coordinates for {vertices.shape[0]} vertices"
+        )
+
+    uv = np.asarray(uv_coords[:, :2], dtype=np.float64)
+    valid_vertex_mask = np.isfinite(uv).all(axis=1)
+    valid_faces_mask = np.all(valid_vertex_mask[faces], axis=1)
+
+    if not valid_faces_mask.any():
+        return UVSetInfo(name=uv_set_name, charts=[], udims=set(), per_material_udims={})
+
+    faces_subset = faces[valid_faces_mask]
+    face_materials_subset = face_materials[valid_faces_mask]
+    adjacency = _build_uv_adjacency(faces_subset, uv, eps=_UV_EPSILON)
+    islands = _connected_components(adjacency)
+
+    tangents, bitangents, _normals, orientation = compute_triangle_tangent_frames(
+        vertices, faces_subset, uv
+    )
+
+    used_vertices = np.unique(faces_subset.reshape(-1))
+    udim_list = _compute_udims(uv, used_vertices)
+
+    vertex_udims = _compute_vertex_udims(uv)
+    face_udims = [_collect_face_udims(face, vertex_udims) for face in faces_subset]
+
+    charts, chart_faces = _build_charts(
+        faces_subset,
+        islands,
+        uv,
+        tangents,
+        bitangents,
+        orientation,
+        adjacency,
+        face_materials_subset,
+        face_udims,
+        materials,
+    )
+
+    per_material_udims: Dict[int, Set[int]] = {}
+    for chart in charts:
+        per_material_udims.setdefault(chart.material_id, set()).update(chart.udims)
+
+    face_chart_ids = np.zeros(len(faces_subset), dtype=np.int32)
+    for chart_id, indices in chart_faces.items():
+        face_chart_ids[indices] = int(chart_id)
+
+    mesh_data = UVSetMeshData(
+        faces=faces_subset,
+        uv=uv,
+        face_materials=face_materials_subset,
+        face_chart_ids=face_chart_ids,
+        chart_faces=chart_faces,
+        face_udims=tuple(face_udims),
+    )
+
+    return UVSetInfo(
+        name=uv_set_name,
+        charts=charts,
+        udims=set(udim_list),
+        per_material_udims=per_material_udims,
+        mesh_data=mesh_data,
+    )
+
+
+def _ensure_pyassimp_dependencies() -> None:
+    try:
+        import distutils  # type: ignore  # noqa: F401
+    except ModuleNotFoundError:
+        try:
+            distutils_module = importlib.import_module("setuptools._distutils")
+            sys.modules.setdefault("distutils", distutils_module)
+            sys.modules.setdefault(
+                "distutils.sysconfig",
+                importlib.import_module("setuptools._distutils.sysconfig"),
+            )
+        except ModuleNotFoundError as exc:  # pragma: no cover - environment specific
+            raise MeshLoadError(
+                "pyassimp requires setuptools to provide distutils on this Python version"
+            ) from exc
+
+    system_site = Path("/usr/lib/python3/dist-packages")
+    system_site_str = str(system_site)
+    if system_site.exists() and system_site_str not in sys.path:
+        sys.path.append(system_site_str)
+
+
+def _build_uv_adjacency(
+    faces: np.ndarray,
+    uv: np.ndarray,
+    *,
+    eps: float,
+) -> List[List[int]]:
+    adjacency: List[List[int]] = [[] for _ in range(len(faces))]
+    edge_to_faces: Dict[Tuple[int, int], List[Tuple[int, int, int]]] = {}
+
+    for face_index, face in enumerate(faces):
+        for offset in range(3):
+            vi = int(face[offset])
+            vj = int(face[(offset + 1) % 3])
+
+            if not _uv_vertex_finite(uv, vi) or not _uv_vertex_finite(uv, vj):
+                continue
+
+            key = (vi, vj) if vi < vj else (vj, vi)
+            edge_to_faces.setdefault(key, []).append((face_index, vi, vj))
+
+    for uses in edge_to_faces.values():
+        if len(uses) < 2:
+            continue
+
+        for idx_a in range(len(uses)):
+            face_a, a_v0, a_v1 = uses[idx_a]
+            uv_a0 = uv[a_v0]
+            uv_a1 = uv[a_v1]
+
+            for idx_b in range(idx_a + 1, len(uses)):
+                face_b, b_v0, b_v1 = uses[idx_b]
+                uv_b0 = uv[b_v0]
+                uv_b1 = uv[b_v1]
+
+                if _uv_edge_matches(uv_a0, uv_a1, uv_b0, uv_b1, eps):
+                    adjacency[face_a].append(face_b)
+                    adjacency[face_b].append(face_a)
+
+    return [sorted(set(neighbours)) for neighbours in adjacency]
+
+
+def _connected_components(adjacency: Sequence[Sequence[int]]) -> List[List[int]]:
+    if not adjacency:
+        return []
+
+    visited = np.zeros(len(adjacency), dtype=bool)
+    components: List[List[int]] = []
+
+    for start in range(len(adjacency)):
+        if visited[start]:
+            continue
+        stack = [start]
+        component: List[int] = []
+        while stack:
+            current = stack.pop()
+            if visited[current]:
+                continue
+            visited[current] = True
+            component.append(current)
+            for neighbour in adjacency[current]:
+                if not visited[neighbour]:
+                    stack.append(neighbour)
+        components.append(component)
+
+    return components
+
+
+def _build_charts(
+    faces: np.ndarray,
+    islands: Sequence[Sequence[int]],
+    uv: np.ndarray,
+    tangents: np.ndarray,
+    bitangents: np.ndarray,
+    orientation: np.ndarray,
+    adjacency: Sequence[Sequence[int]],
+    face_materials: np.ndarray,
+    face_udims: Sequence[Set[int]],
+    materials: Mapping[int, str],
+) -> Tuple[List[ChartInfo], Dict[int, np.ndarray]]:
+    charts: List[ChartInfo] = []
+    chart_faces: Dict[int, np.ndarray] = {}
+
+    for chart_id, island in enumerate(islands, start=1):
+        face_indices = np.array(island, dtype=int)
+        chart_faces[chart_id] = face_indices
+        island_faces = faces[face_indices]
+        vertex_indices = np.unique(island_faces.reshape(-1))
+        uv_coords = uv[vertex_indices]
+        finite_mask = np.isfinite(uv_coords).all(axis=1)
+
+        if finite_mask.any():
+            uv_valid = uv_coords[finite_mask]
+            bbox_min = uv_valid.min(axis=0)
+            bbox_max = uv_valid.max(axis=0)
+            bbox_uv = (
+                float(bbox_min[0]),
+                float(bbox_min[1]),
+                float(bbox_max[0]),
+                float(bbox_max[1]),
+            )
+        else:
+            bbox_uv = (0.0, 0.0, 0.0, 0.0)
+
+        orientation_values = orientation[face_indices]
+        neg_count = int(np.sum(orientation_values < 0))
+        pos_count = int(np.sum(orientation_values > 0))
+        mirrored = neg_count > pos_count
+
+        flip_u = False
+        flip_v = False
+        if mirrored:
+            flip_u, flip_v = _determine_mirror_axis(adjacency, island, tangents, bitangents)
+
+        material_counter = Counter(int(face_materials[idx]) for idx in face_indices)
+        if material_counter:
+            dominant_material_id = min(
+                material_counter.items(), key=lambda item: (-item[1], item[0])
+            )[0]
+        else:
+            dominant_material_id = -1
+
+        if dominant_material_id >= 0:
+            material_name = materials.get(dominant_material_id, f"Material{dominant_material_id}")
+        else:
+            material_name = "<unknown>"
+
+        chart_udims: Set[int] = set()
+        for idx in face_indices:
+            chart_udims.update(face_udims[idx])
+
+        charts.append(
+            ChartInfo(
+                id=chart_id,
+                face_count=int(len(face_indices)),
+                bbox_uv=bbox_uv,
+                mirrored=mirrored,
+                flip_u=flip_u,
+                flip_v=flip_v,
+                material_id=int(dominant_material_id),
+                material_name=material_name,
+                udims=chart_udims,
+            )
+        )
+
+    return charts, chart_faces
+
+
+def _determine_mirror_axis(
+    adjacency: Sequence[Sequence[int]],
+    island: Sequence[int],
+    tangents: np.ndarray,
+    bitangents: np.ndarray,
+) -> Tuple[bool, bool]:
+    island_set = set(int(face_index) for face_index in island)
+    processed_pairs = set()
+    t_inversions = 0
+    t_pairs = 0
+    b_inversions = 0
+    b_pairs = 0
+
+    for face_index in island_set:
+        for neighbour in adjacency[face_index]:
+            if neighbour not in island_set:
+                continue
+            pair = (min(face_index, neighbour), max(face_index, neighbour))
+            if pair in processed_pairs:
+                continue
+            processed_pairs.add(pair)
+
+            tangent_a = tangents[face_index]
+            tangent_b = tangents[neighbour]
+            bitangent_a = bitangents[face_index]
+            bitangent_b = bitangents[neighbour]
+
+            if _vector_valid(tangent_a) and _vector_valid(tangent_b):
+                t_pairs += 1
+                if float(np.dot(tangent_a, tangent_b)) < 0.0:
+                    t_inversions += 1
+
+            if _vector_valid(bitangent_a) and _vector_valid(bitangent_b):
+                b_pairs += 1
+                if float(np.dot(bitangent_a, bitangent_b)) < 0.0:
+                    b_inversions += 1
+
+    if t_pairs == 0 and b_pairs == 0:
+        return True, False
+
+    t_ratio = t_inversions / t_pairs if t_pairs else 0.0
+    b_ratio = b_inversions / b_pairs if b_pairs else 0.0
+
+    if t_ratio > b_ratio:
+        return True, False
+    if b_ratio > t_ratio:
+        return False, True
+    return True, False
+
+
+def _compute_vertex_udims(uv: np.ndarray) -> np.ndarray:
+    vertex_udims = np.full(uv.shape[0], -1, dtype=np.int32)
+    finite_mask = np.isfinite(uv).all(axis=1)
+    if not finite_mask.any():
+        return vertex_udims
+
+    finite_uv = uv[finite_mask]
+    tiles_u = np.floor(finite_uv[:, 0]).astype(int)
+    tiles_v = np.floor(finite_uv[:, 1]).astype(int)
+    vertex_udims[finite_mask] = 1001 + tiles_u + 10 * tiles_v
+    return vertex_udims
+
+
+def _collect_face_udims(face: np.ndarray, vertex_udims: np.ndarray) -> Set[int]:
+    tiles: Set[int] = set()
+    for vertex_index in face:
+        tile = int(vertex_udims[int(vertex_index)])
+        if tile >= 0:
+            tiles.add(tile)
+    return tiles
+
+
+def _compute_udims(uv: np.ndarray, vertex_indices: np.ndarray) -> List[int]:
+    if vertex_indices.size == 0:
+        return []
+
+    coords = uv[vertex_indices]
+    finite_mask = np.isfinite(coords).all(axis=1)
+    coords = coords[finite_mask]
+    if coords.size == 0:
+        return []
+
+    tiles_u = np.floor(coords[:, 0]).astype(int)
+    tiles_v = np.floor(coords[:, 1]).astype(int)
+    tiles = 1001 + tiles_u + 10 * tiles_v
+    return sorted(int(tile) for tile in set(tiles))
+
+
+def _uv_vertex_finite(uv: np.ndarray, index: int) -> bool:
+    coord = uv[index]
+    return bool(np.isfinite(coord).all())
+
+
+def _uv_edge_matches(
+    a0: np.ndarray,
+    a1: np.ndarray,
+    b0: np.ndarray,
+    b1: np.ndarray,
+    eps: float,
+) -> bool:
+    return (_uv_points_close(a0, b0, eps) and _uv_points_close(a1, b1, eps)) or (
+        _uv_points_close(a0, b1, eps) and _uv_points_close(a1, b0, eps)
+    )
+
+
+def _uv_points_close(p: np.ndarray, q: np.ndarray, eps: float) -> bool:
+    return float(np.max(np.abs(p - q))) <= eps
+
+
+def _vector_valid(vec: np.ndarray, eps: float = _VECTOR_EPSILON) -> bool:
+    return bool(np.linalg.norm(vec) > eps)

--- a/normal2disp/n2d/mesh_utils.py
+++ b/normal2disp/n2d/mesh_utils.py
@@ -1,0 +1,98 @@
+"""Mesh loading and analysis helpers used by ``n2d.inspect``."""
+
+from __future__ import annotations
+
+from typing import Any, Tuple
+
+import numpy as np
+import trimesh
+
+__all__ = ["assimp_mesh_to_trimesh", "compute_triangle_tangent_frames"]
+
+
+def assimp_mesh_to_trimesh(mesh: Any) -> trimesh.Trimesh:
+    """Convert a pyassimp mesh to a :class:`trimesh.Trimesh` instance."""
+
+    vertices = np.asarray(getattr(mesh, "vertices", ()), dtype=np.float64)
+    faces_seq = getattr(mesh, "faces", ())
+    faces = np.array(
+        [np.asarray(face, dtype=np.int64) for face in faces_seq if len(face) == 3],
+        dtype=np.int64,
+    )
+
+    if vertices.ndim != 2 or vertices.shape[1] < 3:
+        raise ValueError("Mesh vertices are missing or malformed")
+    if faces.size == 0:
+        raise ValueError("Mesh does not contain any triangular faces")
+
+    return trimesh.Trimesh(
+        vertices=vertices[:, :3],
+        faces=faces,
+        process=False,
+        maintain_order=True,
+    )
+
+
+def compute_triangle_tangent_frames(
+    vertices: np.ndarray,
+    faces: np.ndarray,
+    uv: np.ndarray,
+    *,
+    eps: float = 1e-12,
+) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    """Compute per-triangle tangent frames.
+
+    Returns ``(tangent, bitangent, normal, orientation_sign)`` arrays.
+    """
+
+    face_count = int(faces.shape[0])
+    tangents = np.zeros((face_count, 3), dtype=np.float64)
+    bitangents = np.zeros((face_count, 3), dtype=np.float64)
+    normals = np.zeros((face_count, 3), dtype=np.float64)
+    orientation = np.zeros(face_count, dtype=np.float64)
+
+    for face_index, face in enumerate(faces):
+        idx0, idx1, idx2 = (int(face[0]), int(face[1]), int(face[2]))
+        p0, p1, p2 = vertices[idx0], vertices[idx1], vertices[idx2]
+        uv0, uv1, uv2 = uv[idx0], uv[idx1], uv[idx2]
+
+        if not (np.all(np.isfinite(uv0)) and np.all(np.isfinite(uv1)) and np.all(np.isfinite(uv2))):
+            continue
+
+        edge1 = p1 - p0
+        edge2 = p2 - p0
+        normal = np.cross(edge1, edge2)
+        normal_length = float(np.linalg.norm(normal))
+        if normal_length < eps:
+            continue
+
+        du1, dv1 = uv1 - uv0
+        du2, dv2 = uv2 - uv0
+        denom = du1 * dv2 - dv1 * du2
+        if abs(float(denom)) < eps:
+            continue
+
+        factor = 1.0 / float(denom)
+        tangent = (edge1 * dv2 - edge2 * dv1) * factor
+        bitangent = (edge2 * du1 - edge1 * du2) * factor
+
+        tangent_length = float(np.linalg.norm(tangent))
+        bitangent_length = float(np.linalg.norm(bitangent))
+        if tangent_length < eps or bitangent_length < eps:
+            continue
+
+        tangent /= tangent_length
+        bitangent /= bitangent_length
+        normal_unit = normal / normal_length
+
+        tangents[face_index] = tangent
+        bitangents[face_index] = bitangent
+        normals[face_index] = normal_unit
+
+        handedness = float(np.dot(np.cross(tangent, bitangent), normal_unit))
+        if handedness > eps:
+            orientation[face_index] = 1.0
+        elif handedness < -eps:
+            orientation[face_index] = -1.0
+
+    return tangents, bitangents, normals, orientation

--- a/normal2disp/n2d/uv_raster.py
+++ b/normal2disp/n2d/uv_raster.py
@@ -1,0 +1,228 @@
+"""Rasterisation utilities for UV charts."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Dict, List, Mapping, Sequence, Tuple
+
+import cv2
+import numpy as np
+
+from .inspect import ChartInfo, UVSetInfo
+
+__all__ = ["TileChartEntry", "TileRasterResult", "rasterize_uv_charts"]
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class TileChartEntry:
+    """Summary information for a chart within a particular UDIM tile."""
+
+    local_id: int
+    chart_id: int
+    flip_u: bool
+    flip_v: bool
+    pixel_count: int
+    bbox_uv: Tuple[float, float, float, float]
+    bbox_px: Tuple[int, int, int, int]
+
+
+@dataclass(frozen=True)
+class TileRasterResult:
+    """Rasterisation output for a single UDIM tile."""
+
+    tile: int
+    width: int
+    height: int
+    chart_mask: np.ndarray
+    boundary_mask: np.ndarray
+    charts: List[TileChartEntry]
+
+
+def rasterize_uv_charts(
+    uv_info: UVSetInfo,
+    tile_resolutions: Mapping[int, Tuple[int, int]],
+    *,
+    deterministic: bool = False,
+) -> List[TileRasterResult]:
+    """Rasterise the charts for ``uv_info`` using ``tile_resolutions``."""
+
+    mesh_data = uv_info.mesh_data
+    face_chart_ids = mesh_data.face_chart_ids
+    chart_lookup: Dict[int, ChartInfo] = {chart.id: chart for chart in uv_info.charts}
+
+    tile_faces: Dict[int, List[int]] = {}
+    cross_tile_counts: Dict[int, int] = {}
+
+    for face_index, tiles in enumerate(mesh_data.face_udims):
+        if not tiles:
+            continue
+        if len(tiles) == 1:
+            tile = next(iter(tiles))
+            tile_faces.setdefault(tile, []).append(face_index)
+        else:
+            for tile in tiles:
+                cross_tile_counts[tile] = cross_tile_counts.get(tile, 0) + 1
+
+    if cross_tile_counts:
+        warning = ", ".join(f"{tile}: {count}" for tile, count in sorted(cross_tile_counts.items()))
+        _LOGGER.warning(
+            "UV set %s has faces spanning multiple UDIM tiles (triangles per tile: %s)",
+            uv_info.name,
+            warning,
+        )
+
+    for tile in tile_faces:
+        if tile not in tile_resolutions:
+            raise ValueError(f"No resolution available for UDIM {tile}")
+
+    results: List[TileRasterResult] = []
+
+    for tile in sorted(tile_faces):
+        height, width = tile_resolutions[tile]
+        chart_faces = _collect_chart_faces_for_tile(tile_faces[tile], face_chart_ids)
+        if deterministic:
+            sorted_chart_ids = sorted(chart_faces)
+        else:
+            sorted_chart_ids = list(sorted(chart_faces))
+
+        chart_mask = np.zeros((height, width), dtype=np.int32)
+        chart_entries: List[TileChartEntry] = []
+
+        tile_u, tile_v = _tile_to_indices(tile)
+        for local_offset, chart_id in enumerate(sorted_chart_ids, start=1):
+            face_indices = chart_faces[chart_id]
+            uv_bounds: List[np.ndarray] = []
+            for face_index in face_indices:
+                face = mesh_data.faces[face_index]
+                uv_coords = mesh_data.uv[face]
+                local_uv = _localise_uv(uv_coords, tile_u, tile_v)
+                uv_bounds.append(local_uv)
+                _rasterize_triangle(chart_mask, local_uv, width, height, local_offset)
+
+            uv_concat = np.concatenate(uv_bounds, axis=0) if uv_bounds else np.zeros((0, 2))
+            bbox_uv = _compute_uv_bbox(uv_concat)
+            pixel_count, bbox_px = _compute_pixel_stats(chart_mask, local_offset)
+
+            chart = chart_lookup.get(chart_id)
+            flip_u = chart.flip_u if chart else False
+            flip_v = chart.flip_v if chart else False
+
+            chart_entries.append(
+                TileChartEntry(
+                    local_id=local_offset,
+                    chart_id=chart_id,
+                    flip_u=flip_u,
+                    flip_v=flip_v,
+                    pixel_count=pixel_count,
+                    bbox_uv=bbox_uv,
+                    bbox_px=bbox_px,
+                )
+            )
+
+        boundary_mask = _compute_boundary_mask(chart_mask)
+        results.append(
+            TileRasterResult(
+                tile=tile,
+                width=width,
+                height=height,
+                chart_mask=chart_mask,
+                boundary_mask=boundary_mask,
+                charts=chart_entries,
+            )
+        )
+
+    return results
+
+
+def _collect_chart_faces_for_tile(
+    face_indices: Sequence[int], face_chart_ids: np.ndarray
+) -> Dict[int, List[int]]:
+    mapping: Dict[int, List[int]] = {}
+    for face_index in face_indices:
+        chart_id = int(face_chart_ids[face_index])
+        if chart_id <= 0:
+            continue
+        mapping.setdefault(chart_id, []).append(face_index)
+    return mapping
+
+
+def _tile_to_indices(tile: int) -> Tuple[int, int]:
+    offset = tile - 1001
+    u = offset % 10
+    v = offset // 10
+    return u, v
+
+
+def _localise_uv(uv_coords: np.ndarray, tile_u: int, tile_v: int) -> np.ndarray:
+    local = np.empty_like(uv_coords, dtype=np.float64)
+    local[:, 0] = uv_coords[:, 0] - float(tile_u)
+    local[:, 1] = uv_coords[:, 1] - float(tile_v)
+    return np.clip(local, 0.0, 1.0)
+
+
+def _rasterize_triangle(
+    mask: np.ndarray,
+    uv_coords: np.ndarray,
+    width: int,
+    height: int,
+    value: int,
+) -> None:
+    points = _uv_to_pixels(uv_coords, width, height)
+    cv2.fillConvexPoly(mask, points, int(value), lineType=cv2.LINE_8)
+
+
+def _uv_to_pixels(uv_coords: np.ndarray, width: int, height: int) -> np.ndarray:
+    u = np.clip(uv_coords[:, 0], 0.0, 1.0)
+    v = np.clip(uv_coords[:, 1], 0.0, 1.0)
+    x = np.floor(np.clip(u * width, 0.0, width - 1e-6)).astype(np.int32)
+    y = np.floor(np.clip((1.0 - v) * height, 0.0, height - 1e-6)).astype(np.int32)
+    return np.stack([x, y], axis=1)
+
+
+def _compute_uv_bbox(uv_coords: np.ndarray) -> Tuple[float, float, float, float]:
+    if uv_coords.size == 0:
+        return (0.0, 0.0, 0.0, 0.0)
+    u_min = float(np.min(uv_coords[:, 0]))
+    v_min = float(np.min(uv_coords[:, 1]))
+    u_max = float(np.max(uv_coords[:, 0]))
+    v_max = float(np.max(uv_coords[:, 1]))
+    return (u_min, v_min, u_max, v_max)
+
+
+def _compute_pixel_stats(
+    mask: np.ndarray, chart_value: int
+) -> Tuple[int, Tuple[int, int, int, int]]:
+    positions = np.argwhere(mask == chart_value)
+    if positions.size == 0:
+        return 0, (0, 0, 0, 0)
+
+    y_coords = positions[:, 0]
+    x_coords = positions[:, 1]
+    y0 = int(y_coords.min())
+    y1 = int(y_coords.max()) + 1
+    x0 = int(x_coords.min())
+    x1 = int(x_coords.max()) + 1
+    return int(len(positions)), (x0, y0, x1, y1)
+
+
+def _compute_boundary_mask(mask: np.ndarray) -> np.ndarray:
+    boundary = np.zeros_like(mask, dtype=np.uint8)
+
+    # Horizontal differences
+    left = mask[:, :-1]
+    right = mask[:, 1:]
+    diff = (left != right) & ((left > 0) | (right > 0))
+    boundary[:, :-1][diff] = 1
+    boundary[:, 1:][diff] = 1
+
+    # Vertical differences
+    top = mask[:-1, :]
+    bottom = mask[1:, :]
+    diff = (top != bottom) & ((top > 0) | (bottom > 0))
+    boundary[:-1, :][diff] = 1
+    boundary[1:, :][diff] = 1
+
+    return boundary

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,29 @@
+[build-system]
+requires = ["setuptools>=66", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "normal2disp"
+version = "0.1.0"
+description = "Tangent-space normal map to displacement converter."
+readme = "README.md"
+requires-python = ">=3.10"
+dependencies = []
+
+[project.scripts]
+n2d = "normal2disp.n2d.cli:main"
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["normal2disp*"]
+
+[tool.black]
+line-length = 100
+target-version = ["py312"]
+
+[tool.ruff]
+line-length = 100
+target-version = "py312"
+
+[tool.pytest.ini_options]
+addopts = "-q"

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import base64
+from pathlib import Path
+
+import cv2
+import numpy as np
+
+from normal2disp.n2d.image_utils import _ensure_system_site_packages
+
+_DUMMY_PNG = base64.b64decode(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9YfD+VsAAAAASUVORK5CYII="
+)
+
+
+def write_two_island_asset(directory: Path) -> Path:
+    obj_data = """\
+o TwoIslands
+mtllib two_islands.mtl
+v 0 0 0
+v 1 0 0
+v 1 1 0
+v 0 1 0
+v 2 0 0
+v 3 0 0
+v 3 1 0
+v 2 1 0
+vt 0.05 0.05
+vt 0.95 0.05
+vt 0.95 0.95
+vt 0.05 0.95
+vt 1.95 0.05
+vt 1.05 0.05
+vt 1.95 0.95
+vt 1.05 0.95
+usemtl matA
+f 1/1 2/2 3/3
+f 1/1 3/3 4/4
+usemtl matB
+f 5/5 6/6 7/7
+f 5/5 7/7 8/8
+"""
+    mtl_data = """\
+newmtl matA
+Kd 1.0 0.0 0.0
+newmtl matB
+Kd 0.0 1.0 0.0
+"""
+
+    obj_path = directory / "two_islands.obj"
+    (directory / "two_islands.mtl").write_text(mtl_data, encoding="utf-8")
+    obj_path.write_text(obj_data, encoding="utf-8")
+    return obj_path
+
+
+def write_dummy_png(path: Path, size: int = 1) -> None:
+    if size <= 1:
+        path.write_bytes(_DUMMY_PNG)
+        return
+
+    image = np.full((size, size, 3), 128, dtype=np.uint8)
+    if not cv2.imwrite(str(path), image):  # pragma: no cover - defensive
+        raise RuntimeError(f"Failed to write dummy PNG to {path}")
+
+
+def read_exr_pixels(path: Path) -> np.ndarray:
+    _ensure_system_site_packages()
+    import OpenImageIO as oiio  # type: ignore
+
+    buf = oiio.ImageBuf(str(path))
+    spec = buf.spec()
+    array = np.array(buf.get_pixels(oiio.FLOAT))
+    return array.reshape(spec.height, spec.width, spec.nchannels)

--- a/tests/test_bake.py
+++ b/tests/test_bake.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import numpy as np
+
+from .helpers import read_exr_pixels, write_dummy_png, write_two_island_asset
+
+
+def _sidecar_dir(mesh_path: Path) -> Path:
+    return mesh_path.parent / f"{mesh_path.stem}_sidecars"
+
+
+def _run_bake_command(args: list[str], *, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(args, check=check, capture_output=True, text=True)
+
+
+def test_bake_export_sidecars_produces_assets(tmp_path: Path) -> None:
+    obj_path = write_two_island_asset(tmp_path)
+    texture_dir = tmp_path / "textures"
+    texture_dir.mkdir()
+    write_dummy_png(texture_dir / "normal_1001.png", size=256)
+    write_dummy_png(texture_dir / "normal_1002.png", size=256)
+
+    cmd = [
+        sys.executable,
+        "-m",
+        "normal2disp.n2d.cli",
+        "bake",
+        str(obj_path),
+        "--validate-only",
+        "--uv-set",
+        "UV0",
+        "--normal",
+        str(texture_dir / "normal_<UDIM>.png"),
+        "--export-sidecars",
+    ]
+
+    result = _run_bake_command(cmd)
+    report = json.loads(result.stdout)
+    assert "sidecars" in report
+
+    sidecar_dir = _sidecar_dir(obj_path)
+    expected_tiles = [1001, 1002]
+    for tile in expected_tiles:
+        chart_id_path = sidecar_dir / f"UV0_{tile}_chart_id.exr"
+        boundary_path = sidecar_dir / f"UV0_{tile}_boundary.exr"
+        table_path = sidecar_dir / f"UV0_{tile}_chart_table.json"
+
+        assert chart_id_path.exists()
+        assert boundary_path.exists()
+        assert table_path.exists()
+
+        chart_pixels = read_exr_pixels(chart_id_path)
+        boundary_pixels = read_exr_pixels(boundary_path)
+        assert chart_pixels.shape[2] == 1
+        assert boundary_pixels.shape[2] == 1
+
+        chart_mask = np.squeeze(chart_pixels)
+        boundary_mask = np.squeeze(boundary_pixels)
+        assert chart_mask.shape == boundary_mask.shape == (256, 256)
+        assert np.max(chart_mask) >= 1
+        assert np.count_nonzero(boundary_mask) > 0
+
+        table = json.loads(table_path.read_text(encoding="utf-8"))
+        assert table["tile"] == tile
+        assert table["uv_set"] == "UV0"
+        assert table["y_channel"] in {"+Y", "-Y"}
+        assert table["charts"]
+        for entry in table["charts"]:
+            assert entry["pixel_count"] > 0
+            assert len(entry["bbox_uv"]) == 4
+            assert len(entry["bbox_px"]) == 4
+
+
+def test_bake_export_sidecars_deterministic(tmp_path: Path) -> None:
+    obj_path = write_two_island_asset(tmp_path)
+    texture_dir = tmp_path / "textures"
+    texture_dir.mkdir()
+    write_dummy_png(texture_dir / "normal_1001.png", size=128)
+    write_dummy_png(texture_dir / "normal_1002.png", size=128)
+
+    base_cmd = [
+        sys.executable,
+        "-m",
+        "normal2disp.n2d.cli",
+        "bake",
+        str(obj_path),
+        "--validate-only",
+        "--uv-set",
+        "UV0",
+        "--normal",
+        str(texture_dir / "normal_<UDIM>.png"),
+        "--export-sidecars",
+        "--deterministic",
+    ]
+
+    _run_bake_command(base_cmd)
+    sidecar_dir = _sidecar_dir(obj_path)
+    first_masks = {
+        path.name: read_exr_pixels(path) for path in sorted(sidecar_dir.glob("UV0_*_chart_id.exr"))
+    }
+
+    _run_bake_command(base_cmd)
+    second_masks = {
+        path.name: read_exr_pixels(path) for path in sorted(sidecar_dir.glob("UV0_*_chart_id.exr"))
+    }
+
+    assert first_masks.keys() == second_masks.keys()
+    for name in first_masks:
+        assert np.array_equal(first_masks[name], second_masks[name])
+
+
+def test_bake_export_sidecars_mixed_resolution_fails(tmp_path: Path) -> None:
+    obj_path = write_two_island_asset(tmp_path)
+    texture_dir = tmp_path / "textures"
+    texture_dir.mkdir()
+    write_dummy_png(texture_dir / "matA_1001.png", size=128)
+    write_dummy_png(texture_dir / "matA_1002.png", size=128)
+    write_dummy_png(texture_dir / "matB_1001.png", size=64)
+    write_dummy_png(texture_dir / "matB_1002.png", size=64)
+
+    cmd = [
+        sys.executable,
+        "-m",
+        "normal2disp.n2d.cli",
+        "bake",
+        str(obj_path),
+        "--validate-only",
+        "--uv-set",
+        "UV0",
+        "--mat-normal",
+        f"matA={texture_dir / 'matA_<UDIM>.png'}",
+        "--mat-normal",
+        f"matB={texture_dir / 'matB_<UDIM>.png'}",
+        "--export-sidecars",
+    ]
+
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    assert result.returncode != 0
+    assert "mixed resolutions" in (result.stderr or result.stdout)

--- a/tests/test_inspect.py
+++ b/tests/test_inspect.py
@@ -1,0 +1,112 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from .helpers import write_dummy_png, write_two_island_asset
+
+
+def test_inspect_cli_reports_mirroring(tmp_path: Path) -> None:
+    obj_path = write_two_island_asset(tmp_path)
+
+    json_path = tmp_path / "report.json"
+    cmd = [
+        sys.executable,
+        "-m",
+        "normal2disp.n2d.cli",
+        "inspect",
+        str(obj_path),
+        "--inspect-json",
+        str(json_path),
+    ]
+
+    result = subprocess.run(cmd, check=True, capture_output=True, text=True)
+    assert result.returncode == 0
+
+    report = json.loads(json_path.read_text(encoding="utf-8"))
+    assert "uv_sets" in report
+
+    uv_sets = report["uv_sets"]
+    assert isinstance(uv_sets, dict)
+    assert uv_sets
+
+    first_uv_name = sorted(uv_sets)[0]
+    uv_info = uv_sets[first_uv_name]
+    assert uv_info["chart_count"] >= 2
+    assert uv_info["udims"]
+    assert report.get("materials")
+
+    mirrored_charts = [chart for chart in uv_info["charts"] if chart["mirrored"]]
+    assert mirrored_charts, "expected at least one mirrored chart"
+
+    for chart in mirrored_charts:
+        flip_flags = [bool(chart["flip_u"]), bool(chart["flip_v"])]
+        assert sum(flip_flags) == 1
+        assert "material_id" in chart
+        assert chart.get("material_name") in {"matA", "matB"}
+
+    non_mirrored = [chart for chart in uv_info["charts"] if not chart["mirrored"]]
+    assert non_mirrored, "expected at least one non-mirrored chart"
+
+    chart_materials = {chart["material_name"] for chart in uv_info["charts"]}
+    assert {"matA", "matB"}.issubset(chart_materials)
+
+
+def test_bake_validate_only_reports_missing_tiles(tmp_path: Path) -> None:
+    obj_path = write_two_island_asset(tmp_path)
+    texture_dir = tmp_path / "textures"
+    texture_dir.mkdir()
+    write_dummy_png(texture_dir / "normal_1001.png")
+
+    cmd = [
+        sys.executable,
+        "-m",
+        "normal2disp.n2d.cli",
+        "bake",
+        str(obj_path),
+        "--validate-only",
+        "--uv-set",
+        "UV0",
+        "--normal",
+        str(texture_dir / "normal_<UDIM>.png"),
+    ]
+
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    assert result.returncode != 0
+
+    report = json.loads(result.stdout)
+    materials = {material["name"]: material for material in report["materials"]}
+    assert materials["matA"]["missing_tiles"] == []
+    assert materials["matB"]["missing_tiles"] == [1002]
+
+
+def test_bake_validate_only_with_overrides_succeeds(tmp_path: Path) -> None:
+    obj_path = write_two_island_asset(tmp_path)
+    texture_dir = tmp_path / "textures"
+    texture_dir.mkdir()
+    write_dummy_png(texture_dir / "normal_1001.png")
+    write_dummy_png(texture_dir / "other_1002.png")
+
+    cmd = [
+        sys.executable,
+        "-m",
+        "normal2disp.n2d.cli",
+        "bake",
+        str(obj_path),
+        "--validate-only",
+        "--uv-set",
+        "UV0",
+        "--mat-normal",
+        f"matA={texture_dir / 'normal_<UDIM>.png'}",
+        "--mat-normal",
+        f"matB={texture_dir / 'other_<UDIM>.png'}",
+    ]
+
+    result = subprocess.run(cmd, check=True, capture_output=True, text=True)
+
+    report = json.loads(result.stdout)
+    materials = {material["name"]: material for material in report["materials"]}
+    assert materials["matA"]["tiles_found"] == [1001]
+    assert materials["matB"]["tiles_found"] == [1002]
+    assert materials["matA"]["missing_tiles"] == []
+    assert materials["matB"]["missing_tiles"] == []


### PR DESCRIPTION
## Summary
- add a reusable sidecar export pipeline that validates UDIM resolutions, rasterizes charts into per-tile masks, and writes EXR/JSON outputs for bake runs
- extend inspect metadata with UVSetMeshData so bake-time rasterization can reference per-face chart assignments
- update the CLI to expose --export-sidecars/--deterministic flags, surface generated sidecar paths, and cover the workflow with deterministic/mixed-resolution pytest cases

## Testing
- pip install -e .
- ruff check .
- black --check .
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c913a1740c832696fc3bc4584f317a