### PR TITLE
Add GUI skeleton with themed QML layout

### DIFF
--- a/n2d_gui/__init__.py
+++ b/n2d_gui/__init__.py
@@ -1,0 +1,29 @@
+"""Top-level package wrapper that exposes the GUI modules."""
+
+from __future__ import annotations
+
+from importlib import import_module
+from typing import Any
+import sys as _sys
+
+_base_pkg = import_module("normal2disp.gui.n2d_gui")
+
+__all__ = getattr(_base_pkg, "__all__", [])
+
+
+def __getattr__(name: str) -> Any:
+    return getattr(_base_pkg, name)
+
+
+for _module_name in (
+    "app",
+    "backend",
+    "jobs",
+    "image_provider",
+    "models",
+    "subdivision",
+    "viewport",
+):
+    _sys.modules[f"{__name__}.{_module_name}"] = import_module(
+        f"normal2disp.gui.n2d_gui.{_module_name}"
+    )

--- a/normal2disp/gui/n2d_gui/__init__.py
+++ b/normal2disp/gui/n2d_gui/__init__.py
@@ -1,0 +1,12 @@
+"""GUI package for the normal2disp application."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+__all__ = ["qml_path"]
+
+
+def qml_path() -> Path:
+    """Return the root directory that stores the QML resources."""
+    return Path(__file__).resolve().parent.parent / "qml"

--- a/normal2disp/gui/n2d_gui/app.py
+++ b/normal2disp/gui/n2d_gui/app.py
@@ -1,0 +1,38 @@
+"""Application entry point for the normal2disp GUI."""
+
+from __future__ import annotations
+
+import sys
+
+from PySide6.QtGui import QGuiApplication
+from PySide6.QtQml import QQmlApplicationEngine
+from PySide6.QtQuickControls2 import QQuickStyle
+
+from . import qml_path
+
+__all__ = ["main"]
+
+
+def main() -> int:
+    """Launch the GUI application."""
+    QQuickStyle.setStyle("Material")
+
+    app = QGuiApplication(sys.argv)
+    app.setOrganizationName("normal2disp")
+    app.setApplicationName("normal2disp GUI")
+
+    engine = QQmlApplicationEngine()
+
+    qml_dir = qml_path()
+    engine.addImportPath(str(qml_dir))
+    main_window = qml_dir / "MainWindow.qml"
+    engine.load(str(main_window))
+
+    if not engine.rootObjects():
+        return -1
+
+    return app.exec()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/normal2disp/gui/n2d_gui/backend.py
+++ b/normal2disp/gui/n2d_gui/backend.py
@@ -1,0 +1,10 @@
+"""Placeholder backend bridge for GUI milestone P0."""
+
+from __future__ import annotations
+
+
+class Backend:
+    """Placeholder QObject bridge that will be implemented in later milestones."""
+
+    def __init__(self) -> None:
+        pass

--- a/normal2disp/gui/n2d_gui/image_provider.py
+++ b/normal2disp/gui/n2d_gui/image_provider.py
@@ -1,0 +1,10 @@
+"""Placeholder image provider module."""
+
+from __future__ import annotations
+
+
+class PreviewImageProvider:
+    """Stub image provider to satisfy the module layout for milestone P0."""
+
+    def __init__(self) -> None:
+        pass

--- a/normal2disp/gui/n2d_gui/jobs.py
+++ b/normal2disp/gui/n2d_gui/jobs.py
@@ -1,0 +1,10 @@
+"""Job orchestration stubs for future GUI milestones."""
+
+from __future__ import annotations
+
+
+class JobRunner:
+    """Placeholder class for job orchestration."""
+
+    def __init__(self) -> None:
+        pass

--- a/normal2disp/gui/n2d_gui/models.py
+++ b/normal2disp/gui/n2d_gui/models.py
@@ -1,0 +1,19 @@
+"""Model definitions placeholder for milestone P0."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List
+
+
+@dataclass
+class PlaceholderOption:
+    """Represents a placeholder option entry."""
+
+    name: str
+
+
+def default_options() -> List[PlaceholderOption]:
+    """Return an empty list for now."""
+
+    return []

--- a/normal2disp/gui/n2d_gui/subdivision.py
+++ b/normal2disp/gui/n2d_gui/subdivision.py
@@ -1,0 +1,9 @@
+"""Subdivision utilities placeholder."""
+
+from __future__ import annotations
+
+
+def subdivide_placeholder() -> None:
+    """Placeholder function for future subdivision logic."""
+
+    return None

--- a/normal2disp/gui/n2d_gui/viewport.py
+++ b/normal2disp/gui/n2d_gui/viewport.py
@@ -1,0 +1,9 @@
+"""Viewport helper placeholders."""
+
+from __future__ import annotations
+
+
+def initialize_viewport() -> None:
+    """Placeholder stub that will be replaced with Quick 3D setup."""
+
+    return None

--- a/normal2disp/gui/qml/LeftPanel.qml
+++ b/normal2disp/gui/qml/LeftPanel.qml
@@ -1,0 +1,333 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+import QtQuick.Dialogs 1.3
+
+Item {
+    id: root
+    property var theme
+
+    property string meshPath: ""
+    property string normalPath: ""
+    property string outputPath: ""
+
+    signal meshSelected(string path)
+    signal normalSelected(string path)
+    signal outputSelected(string path)
+
+    function cleanPath(url) {
+        if (!url) {
+            return ""
+        }
+        var stringValue = url.toString()
+        if (stringValue.startsWith("file:///")) {
+            stringValue = stringValue.substring(8)
+        } else if (stringValue.startsWith("file://")) {
+            stringValue = stringValue.substring(7)
+        }
+        return decodeURIComponent(stringValue)
+    }
+
+    Rectangle {
+        anchors.fill: parent
+        color: theme.surface
+        radius: theme.cornerRadius
+    }
+
+    ScrollView {
+        anchors.fill: parent
+        anchors.margins: theme.padding
+        clip: true
+
+        ColumnLayout {
+            id: content
+            spacing: theme.spacing
+            width: parent.width
+
+            Label {
+                text: "Project"
+                color: theme.textSecondary
+                font.pixelSize: 18
+                Layout.alignment: Qt.AlignLeft
+            }
+
+            Frame {
+                Layout.fillWidth: true
+                background: Rectangle {
+                    color: theme.surfaceAlt
+                    radius: theme.cornerRadius
+                    border.color: theme.border
+                }
+
+                ColumnLayout {
+                    anchors.fill: parent
+                    anchors.margins: theme.padding
+                    spacing: theme.spacing
+
+                    Label {
+                        text: "Mesh"
+                        color: theme.textPrimary
+                    }
+
+                    RowLayout {
+                        spacing: theme.spacing
+                        Layout.fillWidth: true
+
+                        Button {
+                            text: "Browse"
+                            Layout.preferredWidth: 110
+                            onClicked: meshDialog.open()
+                        }
+
+                        Label {
+                            Layout.fillWidth: true
+                            wrapMode: Text.WrapAnywhere
+                            color: theme.textSecondary
+                            text: meshPath === "" ? "No mesh selected" : meshPath
+                        }
+                    }
+
+                    Label {
+                        text: "Normal map"
+                        color: theme.textPrimary
+                    }
+
+                    RowLayout {
+                        spacing: theme.spacing
+                        Layout.fillWidth: true
+
+                        Button {
+                            text: "Browse"
+                            Layout.preferredWidth: 110
+                            onClicked: normalDialog.open()
+                        }
+
+                        Label {
+                            Layout.fillWidth: true
+                            wrapMode: Text.WrapAnywhere
+                            color: theme.textSecondary
+                            text: normalPath === "" ? "No normal map selected" : normalPath
+                        }
+                    }
+
+                    Label {
+                        text: "Output directory"
+                        color: theme.textPrimary
+                    }
+
+                    RowLayout {
+                        spacing: theme.spacing
+                        Layout.fillWidth: true
+
+                        Button {
+                            text: "Browse"
+                            Layout.preferredWidth: 110
+                            onClicked: outputDialog.open()
+                        }
+
+                        Label {
+                            Layout.fillWidth: true
+                            wrapMode: Text.WrapAnywhere
+                            color: theme.textSecondary
+                            text: outputPath === "" ? "No output folder selected" : outputPath
+                        }
+                    }
+                }
+            }
+
+            Label {
+                text: "Bake options"
+                color: theme.textSecondary
+                font.pixelSize: 18
+                Layout.alignment: Qt.AlignLeft
+            }
+
+            Frame {
+                Layout.fillWidth: true
+                background: Rectangle {
+                    color: theme.surfaceAlt
+                    radius: theme.cornerRadius
+                    border.color: theme.border
+                }
+
+                ColumnLayout {
+                    anchors.fill: parent
+                    anchors.margins: theme.padding
+                    spacing: theme.spacing
+
+                    RowLayout {
+                        Layout.fillWidth: true
+                        spacing: theme.spacing
+
+                        Label {
+                            text: "UV Set"
+                            color: theme.textPrimary
+                        }
+
+                        ComboBox {
+                            Layout.fillWidth: true
+                            model: ["Auto", "UVSet1", "UVSet2"]
+                            enabled: false
+                        }
+                    }
+
+                    CheckBox {
+                        text: "Y is down"
+                        enabled: false
+                        checked: false
+                        font.pixelSize: 14
+                        Layout.alignment: Qt.AlignLeft
+                    }
+
+                    RowLayout {
+                        Layout.fillWidth: true
+                        spacing: theme.spacing
+
+                        Label {
+                            text: "Amplitude"
+                            color: theme.textPrimary
+                        }
+
+                        Slider {
+                            id: amplitudeSlider
+                            from: 0
+                            to: 10
+                            value: 1
+                            Layout.fillWidth: true
+                            onMoved: amplitudeSpin.value = value
+                        }
+
+                        SpinBox {
+                            id: amplitudeSpin
+                            from: 0
+                            to: 10
+                            stepSize: 0.1
+                            value: amplitudeSlider.value
+                            editable: true
+                            Layout.preferredWidth: 80
+                            onValueModified: amplitudeSlider.value = value
+                        }
+                    }
+
+                    RowLayout {
+                        Layout.fillWidth: true
+                        spacing: theme.spacing
+
+                        Label {
+                            text: "Max slope"
+                            color: theme.textPrimary
+                        }
+
+                        Slider {
+                            id: slopeSlider
+                            from: 1
+                            to: 60
+                            value: 10
+                            Layout.fillWidth: true
+                            onMoved: slopeSpin.value = value
+                        }
+
+                        SpinBox {
+                            id: slopeSpin
+                            from: 1
+                            to: 60
+                            stepSize: 1
+                            value: slopeSlider.value
+                            editable: true
+                            Layout.preferredWidth: 80
+                            onValueModified: slopeSlider.value = value
+                        }
+                    }
+
+                    RowLayout {
+                        Layout.fillWidth: true
+                        spacing: theme.spacing
+
+                        Label {
+                            text: "Normalization"
+                            color: theme.textPrimary
+                        }
+
+                        ComboBox {
+                            Layout.fillWidth: true
+                            model: ["Auto", "XYZ", "XY", "None"]
+                            currentIndex: 0
+                        }
+                    }
+
+                    RowLayout {
+                        Layout.fillWidth: true
+                        spacing: theme.spacing
+
+                        Label {
+                            text: "Processes"
+                            color: theme.textPrimary
+                        }
+
+                        SpinBox {
+                            from: 0
+                            to: 32
+                            value: 0
+                            Layout.preferredWidth: 80
+                        }
+                    }
+
+                    CheckBox {
+                        text: "Deterministic"
+                        checked: false
+                        Layout.alignment: Qt.AlignLeft
+                    }
+
+                    CheckBox {
+                        text: "Export sidecars"
+                        checked: false
+                        Layout.alignment: Qt.AlignLeft
+                    }
+
+                    Button {
+                        text: "Inspect Mesh"
+                        enabled: false
+                        Layout.fillWidth: true
+                        onClicked: console.log("Inspect requested (placeholder)")
+                    }
+
+                    Button {
+                        text: "Bake"
+                        Layout.fillWidth: true
+                        highlighted: true
+                        onClicked: console.log("Bake requested (placeholder)")
+                    }
+                }
+            }
+        }
+    }
+
+    FileDialog {
+        id: meshDialog
+        title: "Select mesh"
+        nameFilters: ["Meshes (*.fbx *.obj *.gltf *.glb)", "All files (*)"]
+        onAccepted: {
+            meshPath = cleanPath(selectedFile)
+            meshSelected(meshPath)
+        }
+    }
+
+    FileDialog {
+        id: normalDialog
+        title: "Select normal map"
+        nameFilters: ["Images (*.png *.exr *.tif *.tiff)", "All files (*)"]
+        onAccepted: {
+            normalPath = cleanPath(selectedFile)
+            normalSelected(normalPath)
+        }
+    }
+
+    FolderDialog {
+        id: outputDialog
+        title: "Select output directory"
+        onAccepted: {
+            outputPath = cleanPath(selectedFolder)
+            outputSelected(outputPath)
+        }
+    }
+}

--- a/normal2disp/gui/qml/MainWindow.qml
+++ b/normal2disp/gui/qml/MainWindow.qml
@@ -1,0 +1,63 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+import QtQuick.Window 2.15
+
+import "." as Components
+
+ApplicationWindow {
+    id: window
+    width: 1280
+    height: 720
+    visible: true
+    title: "normal2disp"
+    color: theme.background
+    minimumWidth: 1024
+    minimumHeight: 640
+
+    Components.Theme { id: theme }
+
+    ColumnLayout {
+        anchors.fill: parent
+        spacing: theme.spacing
+        anchors.margins: theme.padding
+
+        RowLayout {
+            id: mainRow
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+            spacing: theme.spacing
+
+            Components.LeftPanel {
+                id: leftPanel
+                theme: theme
+                Layout.preferredWidth: 340
+                Layout.maximumWidth: 360
+                Layout.fillHeight: true
+            }
+
+            Components.Viewport {
+                id: viewport
+                theme: theme
+                Layout.fillWidth: true
+                Layout.fillHeight: true
+                Layout.preferredWidth: 640
+            }
+
+            Components.RightPane {
+                id: rightPane
+                theme: theme
+                Layout.preferredWidth: 320
+                Layout.maximumWidth: 340
+                Layout.fillHeight: true
+            }
+        }
+
+        Components.StatusBar {
+            id: statusBar
+            theme: theme
+            Layout.fillWidth: true
+            Layout.preferredHeight: 200
+        }
+    }
+}

--- a/normal2disp/gui/qml/RightPane.qml
+++ b/normal2disp/gui/qml/RightPane.qml
@@ -1,0 +1,42 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+
+Item {
+    id: root
+    property var theme
+
+    Rectangle {
+        anchors.fill: parent
+        color: theme.surface
+        radius: theme.cornerRadius
+        border.color: theme.border
+    }
+
+    ColumnLayout {
+        anchors.fill: parent
+        anchors.margins: theme.padding
+        spacing: theme.spacing
+
+        Label {
+            text: "Normal Preview"
+            color: theme.textPrimary
+            font.pixelSize: 18
+            Layout.alignment: Qt.AlignLeft
+        }
+
+        Rectangle {
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+            color: theme.surfaceAlt
+            radius: theme.cornerRadius
+            border.color: theme.border
+
+            Label {
+                anchors.centerIn: parent
+                text: "Normal map preview"
+                color: theme.textMuted
+            }
+        }
+    }
+}

--- a/normal2disp/gui/qml/StatusBar.qml
+++ b/normal2disp/gui/qml/StatusBar.qml
@@ -1,0 +1,73 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+
+Item {
+    id: root
+    property var theme
+
+    property string statusText: "Ready"
+    property string logText: "Waiting for job output..."
+    property real progress: 0.0
+
+    Rectangle {
+        anchors.fill: parent
+        color: theme.surface
+        border.color: theme.border
+    }
+
+    ColumnLayout {
+        anchors.fill: parent
+        anchors.margins: theme.padding
+        spacing: theme.spacing
+
+        RowLayout {
+            Layout.fillWidth: true
+            spacing: theme.spacing
+
+            Label {
+                text: statusText
+                color: theme.textPrimary
+                font.pixelSize: 14
+                Layout.fillWidth: true
+            }
+
+            ProgressBar {
+                value: progress
+                from: 0
+                to: 1
+                Layout.preferredWidth: 220
+            }
+
+            Button {
+                text: "Cancel"
+                enabled: false
+            }
+
+            Button {
+                text: "Open Output"
+                enabled: false
+            }
+        }
+
+        Frame {
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+            background: Rectangle {
+                color: theme.surfaceAlt
+                border.color: theme.border
+            }
+
+            ScrollView {
+                anchors.fill: parent
+                TextArea {
+                    text: logText
+                    readOnly: true
+                    color: theme.textSecondary
+                    background: null
+                    wrapMode: Text.Wrap
+                }
+            }
+        }
+    }
+}

--- a/normal2disp/gui/qml/Theme.qml
+++ b/normal2disp/gui/qml/Theme.qml
@@ -1,0 +1,20 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+
+QtObject {
+    id: theme
+
+    readonly property color background: "#101820"
+    readonly property color surface: "#182430"
+    readonly property color surfaceAlt: "#1F2D3A"
+    readonly property color accent: "#4CC9F0"
+    readonly property color accentMuted: "#3A9AD9"
+    readonly property color border: "#233445"
+    readonly property color textPrimary: "#F5F7FA"
+    readonly property color textSecondary: "#B4C5D5"
+    readonly property color textMuted: "#7F93A8"
+
+    readonly property int cornerRadius: 12
+    readonly property int spacing: 12
+    readonly property int padding: 16
+}

--- a/normal2disp/gui/qml/Viewport.qml
+++ b/normal2disp/gui/qml/Viewport.qml
@@ -1,0 +1,25 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+
+Item {
+    id: root
+    property var theme
+
+    Rectangle {
+        anchors.fill: parent
+        gradient: Gradient {
+            GradientStop { position: 0.0; color: theme.surface }
+            GradientStop { position: 1.0; color: theme.surfaceAlt }
+        }
+        radius: theme.cornerRadius
+        border.color: theme.border
+    }
+
+    Label {
+        anchors.centerIn: parent
+        text: "3D Viewport"
+        color: theme.textMuted
+        font.pixelSize: 20
+    }
+}

--- a/normal2disp/gui/requirements.txt
+++ b/normal2disp/gui/requirements.txt
@@ -1,0 +1,2 @@
+# GUI-specific dependencies
+PySide6==6.7.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ n2d = "normal2disp.n2d.cli:main"
 
 [tool.setuptools.packages.find]
 where = ["."]
-include = ["normal2disp*"]
+include = ["normal2disp*", "n2d_gui*"]
 
 [tool.black]
 line-length = 100


### PR DESCRIPTION
## Summary
- add the PySide6-based GUI package structure and expose it through the top-level `n2d_gui` module
- implement a QML main window with themed left controls, viewport, right preview pane, and bottom status/log bar placeholders
- provide GUI requirements and packaging updates so the app is launchable via `python -m n2d_gui.app`

## Testing
- `ruff check .`
- `pytest` *(fails: requires OpenImageIO which is not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ca7c4fc85883268cf23993c898b0eb