### PR TITLE
Add advanced UDIM drawer and light controls

### DIFF
--- a/normal2disp/gui/qml/RightPane.qml
+++ b/normal2disp/gui/qml/RightPane.qml
@@ -85,44 +85,14 @@ Item {
             visible: backend && backend.normalPreviewPath !== ""
             text: backend ? backend.normalPreviewPath : ""
         }
-
-        Expander {
-            visible: backend && backend.udimTileCount > 1
+        Label {
             Layout.fillWidth: true
-            Layout.preferredHeight: implicitHeight
-            text: "Tiles (advanced)"
-
-            contentItem: ColumnLayout {
-                anchors.fill: parent
-                anchors.margins: theme.padding
-                spacing: theme.spacing / 2
-
-                Label {
-                    text: backend && backend.selectedTile !== 0
-                          ? "Active tile: " + backend.selectedTile
-                          : "Active tile: —"
-                    color: theme.textPrimary
-                }
-
-                Flow {
-                    width: parent.width
-                    spacing: theme.spacing / 2
-
-                    Repeater {
-                        model: backend ? backend.udimTiles : []
-
-                        delegate: Button {
-                            text: modelData
-                            checkable: true
-                            checked: backend && backend.selectedTile === Number(modelData)
-                            onClicked: {
-                                if (backend) backend.selectTile(Number(modelData))
-                            }
-                        }
-                    }
-                }
-
-            }
+            wrapMode: Text.Wrap
+            visible: backend && backend.udimTileCount > 1
+            color: theme.textSecondary
+            text: backend && backend.selectedTile !== 0
+                  ? "Active tile: " + backend.selectedTile
+                  : "Active tile: —"
         }
     }
 }

--- a/normal2disp/gui/qml/StatusBar.qml
+++ b/normal2disp/gui/qml/StatusBar.qml
@@ -80,6 +80,41 @@ Item {
             }
         }
 
+        RowLayout {
+            Layout.fillWidth: true
+            spacing: theme.spacing
+            visible: !!backend
+
+            Label {
+                text: "Light azimuth"
+                color: theme.textPrimary
+            }
+
+            Slider {
+                id: azimuthSlider
+                from: 0
+                to: 360
+                Layout.fillWidth: true
+                enabled: !!backend
+                value: backend ? backend.lightAzimuth : 35
+                onMoved: if (backend) backend.setLightAzimuth(value)
+            }
+
+            Binding {
+                target: azimuthSlider
+                property: "value"
+                value: backend ? backend.lightAzimuth : 35
+                when: !azimuthSlider.pressed
+            }
+
+            Label {
+                text: backend ? Math.round(backend.lightAzimuth) + "°" : "35°"
+                color: theme.textSecondary
+                Layout.preferredWidth: 48
+                horizontalAlignment: Text.AlignHCenter
+            }
+        }
+
         Frame {
             Layout.fillWidth: true
             Layout.fillHeight: true

--- a/normal2disp/gui/qml/Viewport.qml
+++ b/normal2disp/gui/qml/Viewport.qml
@@ -32,8 +32,8 @@ Item {
 
             DirectionalLight {
                 id: keyLight
-                eulerRotation.x: -35
-                eulerRotation.y: 35
+                eulerRotation.x: backend ? backend.lightElevation : -35
+                eulerRotation.y: backend ? backend.lightAzimuth : 35
                 brightness: 80
             }
 


### PR DESCRIPTION
## Summary
- add backend support for per-mesh tile preferences, validation warnings, and light direction controls
- introduce an advanced drawer with UDIM tile selection, warnings, and light elevation adjustments
- surface light azimuth control in the status bar and keep right-pane preview in sync with tile selection

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cb825594f88326ad0b1f1d425757e9