### PR TITLE
Add Windows packaging docs and CI

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -1,0 +1,117 @@
+name: Windows GUI Packaging
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  build-windows:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Cache pip downloads
+        uses: actions/cache@v3
+        with:
+          path: ~\AppData\Local\pip\Cache
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements*.txt', 'pyproject.toml', 'pysidedeploy.json') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - name: Install build dependencies
+        shell: pwsh
+        run: |
+          python -m pip install --upgrade pip setuptools wheel
+          python -m pip install -e .
+          python -m pip install -r normal2disp/gui/requirements.txt
+          python -m pip install PySide6==6.7.2 pyside6-deploy==6.7.2 ruff pytest
+
+      - name: Lint and test (headless)
+        shell: pwsh
+        env:
+          QT_QPA_PLATFORM: offscreen
+        run: |
+          python -m ruff check .
+          python -m pytest
+
+      - name: Determine version
+        id: version
+        shell: pwsh
+        run: |
+          $ref = "${{ github.ref }}".Split('/')[-1]
+          if ('${{ github.ref_type }}' -eq 'tag') {
+            if ($ref.StartsWith('v')) {
+              $ref = $ref.Substring(1)
+            }
+          } else {
+            $ref = "0.0.0-dev"
+          }
+          "version=$ref" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+
+      - name: Build Windows bundle
+        shell: pwsh
+        run: |
+          $version = "${{ steps.version.outputs.version }}"
+          if (-not $version) {
+            throw "Could not determine version from ref."
+          }
+          ./packaging/windows/build.ps1 -Configuration Release -Version $version
+
+      - name: Install Inno Setup
+        shell: pwsh
+        run: choco install innosetup -y
+
+      - name: Optional code signing (bundle exe)
+        if: env.N2D_CODESIGN_PFX_PATH != '' && env.N2D_CODESIGN_PFX_PASSWORD != ''
+        shell: pwsh
+        run: |
+          $version = "${{ steps.version.outputs.version }}"
+          $exePath = "dist\windows\$version\bundle\normal2disp-gui.exe"
+          if (Test-Path $exePath) {
+            if (-not (Get-Command signtool.exe -ErrorAction SilentlyContinue)) {
+              Write-Warning "signtool.exe not found; skipping signing."
+              exit 0
+            }
+            $arguments = @("sign", "/fd", "SHA256", "/f", "$env:N2D_CODESIGN_PFX_PATH", "/p", "$env:N2D_CODESIGN_PFX_PASSWORD")
+            if ($env:N2D_CODESIGN_TIMESTAMP_URL) {
+              $arguments += "/tr"
+              $arguments += $env:N2D_CODESIGN_TIMESTAMP_URL
+              $arguments += "/td"
+              $arguments += "SHA256"
+            }
+            $arguments += $exePath
+            & signtool.exe @arguments
+          } else {
+            Write-Warning "Bundle executable not found at $exePath."
+          }
+
+      - name: Build installer
+        shell: pwsh
+        run: |
+          $version = "${{ steps.version.outputs.version }}"
+          $iss = "packaging/windows/installer.iss"
+          $args = @("/DMyAppVersion=$version")
+          if ($env:N2D_CODESIGN_PFX_PATH -and $env:N2D_CODESIGN_PFX_PASSWORD) {
+            $args += "/DSign=1"
+          }
+          & "C:\\Program Files (x86)\\Inno Setup 6\\ISCC.exe" $iss @args
+
+      - name: Upload bundle artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-bundle-${{ steps.version.outputs.version }}
+          path: dist/windows/${{ steps.version.outputs.version }}/bundle
+
+      - name: Upload installer artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-installer-${{ steps.version.outputs.version }}
+          path: dist/windows/${{ steps.version.outputs.version }}/installer

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,16 @@
 __pycache__/
 *.pyc
 normal2disp.egg-info/
+/build/
+/dist/
+/_deploy/
+*.exe
+*.dll
+*.pdb
+*.appx
+*.msi
+*.appxupload
+*.icns
+*.ico
+*.png
+*.jpg

--- a/GUI.md
+++ b/GUI.md
@@ -161,7 +161,7 @@ Cancellation: worker checks an Event between charts and at safe stage boundaries
 ### GUI‑P6 — Packaging & Installers
 
 * Add `pyside6-deploy` config; produce per‑OS bundles.
-* Windows: create Inno Setup script; macOS: codesign/notarize hooks + DMG; Linux: AppImage via linuxdeploy.
+* Windows: create Inno Setup script (**implemented – see `PACKAGING_WIN.md` for usage**); macOS: codesign/notarize hooks + DMG (later); Linux: AppImage via linuxdeploy (later).
 * CI: GitHub Actions matrix builds on tag push; publish artifacts.
 
 ### GUI‑P7 — Polish & Presets

--- a/PACKAGING_WIN.md
+++ b/PACKAGING_WIN.md
@@ -1,0 +1,210 @@
+# Windows Packaging Guide — normal2disp GUI
+
+This document describes how to build the Windows folder bundle and installer for the **normal2disp GUI** on a local Windows 10/11 workstation using **Python 3.12**. The same steps are reflected in the Windows GitHub Actions workflow (`.github/workflows/windows-build.yml`).
+
+> **Important:** All build artifacts (`dist/`, installers, signed binaries, etc.) must stay out of Git. Clean them up or add them to your local `.gitignore` before committing.
+
+---
+
+## 1. Prerequisites
+
+* Windows 10 or 11 with the Desktop Experience.
+* [Python 3.12.x](https://www.python.org/downloads/windows/) installed and available as `py -3.12`.
+* Visual C++ build tools (part of the **Build Tools for Visual Studio 2022**) – required by some Python wheels.
+* Local clone of this repository (e.g., `git clone https://github.com/<org>/normal2disp`).
+* Internet access for installing Python packages and Inno Setup.
+
+Optional (for signing):
+
+* A code-signing certificate in **PFX** format and its password.
+* Timestamp service URL (e.g., DigiCert or Sectigo).
+
+Set the following environment variables before running any signing step:
+
+* `N2D_CODESIGN_PFX_PATH` – absolute path to the `.pfx` file.
+* `N2D_CODESIGN_PFX_PASSWORD` – password for the PFX.
+* `N2D_CODESIGN_TIMESTAMP_URL` – RFC 3161 timestamp server URL (optional but recommended).
+
+These variables are consumed by the Inno Setup script and any optional `signtool` invocations. **Do not** store certificates or passwords in the repository.
+
+---
+
+## 2. Create and Activate a Virtual Environment
+
+```powershell
+cd <repo>\normal2disp
+py -3.12 -m venv .venv
+.venv\Scripts\Activate.ps1
+```
+
+Upgrade packaging helpers inside the environment:
+
+```powershell
+python -m pip install --upgrade pip setuptools wheel
+```
+
+---
+
+## 3. Install Runtime and Development Dependencies
+
+Install the normal2disp CLI + GUI requirements and the development tooling used by the smoke tests:
+
+```powershell
+python -m pip install -e .
+python -m pip install -r normal2disp/gui/requirements.txt
+python -m pip install ruff pytest
+```
+
+Install **PySide6** (matching the GUI requirements) and the deployment tool:
+
+```powershell
+python -m pip install PySide6==6.7.2 pyside6-deploy==6.7.2
+```
+
+> Depending on your Python installation you may also need `python -m pip install build` if you plan to create wheels separately.
+
+Confirm the deploy tool version:
+
+```powershell
+pyside6-deploy --version
+```
+
+---
+
+## 4. Headless Smoke Test
+
+Set Qt to run headless during validation and execute the linters/tests:
+
+```powershell
+$env:QT_QPA_PLATFORM = "offscreen"
+python -m ruff check .
+python -m pytest
+```
+
+Finally, ensure the GUI can start in offscreen mode. The build script runs a short helper that opens the event loop for a split second and exits. To approximate that manually, run:
+
+```powershell
+python -c "from PySide6.QtCore import QTimer; from n2d_gui.app import main; QTimer.singleShot(150, lambda: __import__('PySide6.QtWidgets').QtWidgets.QApplication.instance().quit()); __import__('sys').exit(main())"
+```
+
+If you only need to verify imports, use the lighter check: `python -c "import n2d_gui.app; print('GUI import ok')"`.
+
+Clear the environment variable when you are done testing:
+
+```powershell
+Remove-Item Env:QT_QPA_PLATFORM
+```
+
+---
+
+## 5. Build the Windows Folder Bundle
+
+The PowerShell helper script orchestrates dependency installation, validation, and the `pyside6-deploy` run. Invoke it with the desired semantic version:
+
+```powershell
+pwsh packaging/windows/build.ps1 -Configuration Release -Version 1.2.3
+```
+
+This script performs the following:
+
+1. Ensures `.venv/` exists (creates it with `py -3.12 -m venv` if necessary) and installs required Python packages (`pip`, `setuptools`, `wheel`, `PySide6==6.7.2`, `pyside6-deploy`, `normal2disp`, GUI extras, `ruff`, `pytest`).
+2. Runs the headless smoke tests (`ruff`, `pytest`, and a short offscreen GUI launch) with `QT_QPA_PLATFORM=offscreen`.
+3. Executes `pyside6-deploy` using `pysidedeploy.json`, targeting the entry point `normal2disp/gui/entrypoint.py`.
+4. Writes the resulting folder bundle to `dist/windows/<version>/bundle/` and preserves the temporary work files under `dist/windows/<version>/deploy_work/`.
+
+After completion you should find a structure similar to:
+
+```
+dist/
+  windows/
+    1.2.3/
+      bundle/
+        normal2disp-gui.exe
+        PySide6/...
+        qml/...
+      deploy_work/
+        ... (build intermediates)
+```
+
+> **Reminder:** Do not commit `dist/` or any generated EXE/DLL files.
+
+If you need to rerun the build, delete the corresponding `dist/windows/<version>/` folder first.
+
+---
+
+## 6. Install Inno Setup
+
+Install Inno Setup 6 via your preferred package manager:
+
+```powershell
+winget install --id JRSoftware.InnoSetup -e
+# or
+choco install innosetup -y
+```
+
+Ensure `ISCC.exe` is on your `PATH` or note the installation directory (usually `C:\Program Files (x86)\Inno Setup 6\`).
+
+---
+
+## 7. Build the Installer
+
+Run the Inno Setup compiler against the provided script. Pass the same version number you used for the folder bundle:
+
+```powershell
+$version = "1.2.3"
+$iss = "packaging/windows/installer.iss"
+"C:\Program Files (x86)\Inno Setup 6\ISCC.exe" $iss /DMyAppVersion=$version
+```
+
+Optional signing: If the environment variables `N2D_CODESIGN_PFX_PATH` and `N2D_CODESIGN_PFX_PASSWORD` are populated, append `/DSign=1` to enable the scripted `SignTool` command inside `installer.iss`. You can also export `N2D_CODESIGN_TIMESTAMP_URL` to append ` /tr <url> /td SHA256` to the signing command.
+
+The installer will read files from `dist/windows/<version>/bundle/` and emit `normal2disp-GUI-<version>.exe` (default name) to `dist/windows/<version>/installer/`.
+
+---
+
+## 8. Outputs and Cleanup
+
+* **Folder bundle:** `dist/windows/<version>/bundle/`
+* **Installer:** `dist/windows/<version>/installer/`
+* **Temporary deploy work dir:** `dist/windows/<version>/deploy_work/` (safe to delete after confirming the installer)
+
+After you validate the installer locally:
+
+1. Optionally sign the installer manually if you skipped automatic signing.
+2. Upload the artifacts to your release pipeline or storage.
+3. Delete `dist/` if you no longer need the outputs locally.
+
+Remember, none of these files should be committed.
+
+---
+
+## 9. CI Notes
+
+The GitHub Actions workflow `.github/workflows/windows-build.yml` mirrors the steps above on `windows-latest` runners. On tag builds (`v*`) it:
+
+1. Restores cached pip downloads to speed up installation.
+2. Installs dependencies, runs `ruff` and `pytest` with `QT_QPA_PLATFORM=offscreen`.
+3. Invokes `packaging/windows/build.ps1` to produce `dist/windows/<version>/bundle/`.
+4. Installs Inno Setup and runs `ISCC.exe` with `/DMyAppVersion=<tag-without-v>` (and `/DSign=1` if signing environment variables are defined).
+5. Uploads both the folder bundle and installer as build artifacts.
+
+To enable signing in CI, add encrypted repository secrets that populate `N2D_CODESIGN_PFX_PATH`, `N2D_CODESIGN_PFX_PASSWORD`, and optionally `N2D_CODESIGN_TIMESTAMP_URL`. The workflow automatically toggles signing when these variables are present.
+
+---
+
+## 10. Providing Icon Assets
+
+The installer references a Windows `.ico` file for shortcuts. Place your icon at `assets/icons/normal2disp.ico` (or adjust the path in `installer.iss`) **before** running the bundle/installer steps. The repository includes `assets/icons/PLACEHOLDER.txt` as a reminder; no binary assets ship with the repo.
+
+---
+
+## 11. Troubleshooting
+
+* **PySide6 deployment fails:** Delete the `dist/windows/<version>/deploy_work/` folder and rerun the build script. Verify that `pyside6-deploy --version` matches the pinned PySide6 version.
+* **Missing DLLs at runtime:** Ensure that `pysidedeploy.json` lists all required resources (QML, translations, etc.) and that the entry point is correct.
+* **Installer cannot find bundle files:** Confirm that the version number passed to `ISCC.exe` matches the bundle directory under `dist/windows/`.
+* **Signing errors:** Double-check the environment variables and confirm that `signtool.exe` exists (part of Windows 10 SDK or Visual Studio). Use `signtool sign /?` for syntax details.
+
+---
+
+You are now ready to produce Windows installers for the normal2disp GUI locally or via CI.

--- a/assets/icons/PLACEHOLDER.txt
+++ b/assets/icons/PLACEHOLDER.txt
@@ -1,0 +1,1 @@
+Add your Windows .ico and other icon assets locally before building installers.

--- a/normal2disp/gui/entrypoint.py
+++ b/normal2disp/gui/entrypoint.py
@@ -1,0 +1,16 @@
+"""Standalone entry point for PySide6 deployment tools."""
+
+from __future__ import annotations
+
+import sys
+
+from normal2disp.gui.n2d_gui.app import main
+
+
+def run() -> int:
+    """Launch the GUI and return the exit code."""
+    return main()
+
+
+if __name__ == "__main__":
+    sys.exit(run())

--- a/packaging/windows/build.ps1
+++ b/packaging/windows/build.ps1
@@ -1,0 +1,108 @@
+[CmdletBinding()]
+param(
+    [ValidateSet("Release", "Debug")]
+    [string]$Configuration = "Release",
+    [Parameter(Mandatory = $true)]
+    [string]$Version
+)
+
+$ErrorActionPreference = "Stop"
+
+if ([string]::IsNullOrWhiteSpace($Version)) {
+    throw "-Version must be supplied (e.g., 1.2.3)."
+}
+
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$repoRoot = Resolve-Path (Join-Path $scriptDir "..\..")
+Set-Location -LiteralPath $repoRoot
+
+Write-Host "Repository root:" $repoRoot
+Write-Host "Configuration:" $Configuration
+Write-Host "Version:" $Version
+
+$venvPath = Join-Path $repoRoot ".venv"
+if (-not (Test-Path $venvPath)) {
+    Write-Host "Creating virtual environment at" $venvPath
+    & py -3.12 -m venv $venvPath
+}
+
+$pythonExe = Join-Path $venvPath "Scripts\python.exe"
+$deployExe = Join-Path $venvPath "Scripts\pyside6-deploy.exe"
+
+Write-Host "Upgrading pip/setuptools/wheel"
+& $pythonExe -m pip install --upgrade pip setuptools wheel
+
+Write-Host "Installing project and runtime dependencies"
+& $pythonExe -m pip install -e .
+& $pythonExe -m pip install -r normal2disp/gui/requirements.txt
+& $pythonExe -m pip install PySide6==6.7.2 pyside6-deploy==6.7.2
+
+Write-Host "Installing development tools"
+& $pythonExe -m pip install ruff pytest
+
+Write-Host "Running headless smoke tests"
+$env:QT_QPA_PLATFORM = "offscreen"
+& $pythonExe -m ruff check .
+& $pythonExe -m pytest
+
+$smokeScript = @'
+import sys
+from PySide6.QtCore import QTimer
+from n2d_gui.app import main as gui_main
+
+
+def quit_app() -> None:
+    from PySide6.QtWidgets import QApplication
+
+    app = QApplication.instance()
+    if app is not None:
+        app.quit()
+
+
+if __name__ == "__main__":
+    QTimer.singleShot(200, quit_app)
+    sys.exit(gui_main())
+'@
+
+$smokePath = Join-Path $scriptDir "smoke_test.py"
+Set-Content -Path $smokePath -Value $smokeScript -Encoding UTF8
+try {
+    & $pythonExe $smokePath
+}
+finally {
+    Remove-Item $smokePath -ErrorAction SilentlyContinue
+}
+
+Remove-Item Env:QT_QPA_PLATFORM -ErrorAction SilentlyContinue
+
+$distRoot = Join-Path $repoRoot (Join-Path "dist\windows" $Version)
+$bundleDir = Join-Path $distRoot "bundle"
+$workDir = Join-Path $distRoot "deploy_work"
+
+Write-Host "Preparing output directories under" $distRoot
+Remove-Item $bundleDir -Recurse -Force -ErrorAction SilentlyContinue
+Remove-Item $workDir -Recurse -Force -ErrorAction SilentlyContinue
+New-Item -ItemType Directory -Path $bundleDir -Force | Out-Null
+New-Item -ItemType Directory -Path $workDir -Force | Out-Null
+
+$pysideConfig = Join-Path $repoRoot "pysidedeploy.json"
+if (-not (Test-Path $pysideConfig)) {
+    throw "pysidedeploy.json not found at $pysideConfig"
+}
+
+$pysideArgs = @(
+    "--config-file", $pysideConfig,
+    "--workpath", $workDir,
+    "--distpath", $bundleDir,
+    "--name", "normal2disp-gui"
+)
+
+if ($Configuration -eq "Debug") {
+    $pysideArgs += "--debug"
+}
+
+Write-Host "Running pyside6-deploy"
+& $deployExe @pysideArgs
+
+Write-Host "Bundle created at" $bundleDir
+Write-Host "Temporary work files at" $workDir

--- a/packaging/windows/installer.iss
+++ b/packaging/windows/installer.iss
@@ -1,0 +1,53 @@
+#define MyAppVersion GetDefine("MyAppVersion", "0.0.0")
+#define Sign GetDefine("Sign", "0")
+#define PfxPath GetEnv("N2D_CODESIGN_PFX_PATH")
+#define PfxPassword GetEnv("N2D_CODESIGN_PFX_PASSWORD")
+#define TimestampUrl GetEnv("N2D_CODESIGN_TIMESTAMP_URL")
+
+[Setup]
+AppId={{D7F9B58E-2E8C-4D2D-8A08-29E5EB7A1AF4}}
+AppName=normal2disp GUI
+AppVersion={#MyAppVersion}
+AppPublisher=<Your Org>
+DefaultDirName={autopf}\normal2disp GUI
+DefaultGroupName=normal2disp GUI
+UninstallDisplayIcon={app}\normal2disp-gui.exe
+OutputBaseFilename=normal2disp-GUI-{#MyAppVersion}
+OutputDir=dist\windows\{#MyAppVersion}\installer
+SetupIconFile=assets\icons\normal2disp.ico
+Compression=lzma
+SolidCompression=yes
+ArchitecturesAllowed=x64compatible
+ArchitecturesInstallIn64BitMode=x64
+DisableDirPage=no
+DisableProgramGroupPage=no
+
+#if Sign == "1"
+SignedUninstaller=yes
+SignTool=SignTool
+#endif
+
+[Languages]
+Name: "english"; MessagesFile: "compiler:Default.isl"
+
+[Tasks]
+Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"
+
+[Files]
+Source: "dist\\windows\\{#MyAppVersion}\\bundle\\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
+
+[Icons]
+Name: "{group}\\normal2disp GUI"; Filename: "{app}\\normal2disp-gui.exe"
+Name: "{commondesktop}\\normal2disp GUI"; Filename: "{app}\\normal2disp-gui.exe"; Tasks: desktopicon
+
+[Run]
+Filename: "{app}\\normal2disp-gui.exe"; Description: "{cm:LaunchProgram,normal2disp GUI}"; Flags: nowait postinstall skipifsilent
+
+#if (Sign == "1") && (PfxPath != "") && (PfxPassword != "")
+[SignTool]
+#if TimestampUrl != ""
+Name: "SignTool"; Command: "signtool sign /fd SHA256 /f \"{#PfxPath}\" /p \"{#PfxPassword}\" /tr \"{#TimestampUrl}\" /td SHA256 \"{#file}\""
+#else
+Name: "SignTool"; Command: "signtool sign /fd SHA256 /f \"{#PfxPath}\" /p \"{#PfxPassword}\" \"{#file}\""
+#endif
+#endif

--- a/pysidedeploy.json
+++ b/pysidedeploy.json
@@ -1,0 +1,22 @@
+{
+  "project_dir": ".",
+  "entry_point": "normal2disp/gui/entrypoint.py",
+  "application_name": "normal2disp GUI",
+  "extra_env": {
+    "QT_QPA_PLATFORM": "offscreen"
+  },
+  "include_files": [
+    {
+      "source": "normal2disp/gui/qml",
+      "destination": "qml"
+    }
+  ],
+  "extra_modules": [
+    "normal2disp",
+    "n2d_gui"
+  ],
+  "resources": [],
+  "python_paths": [
+    "normal2disp"
+  ]
+}


### PR DESCRIPTION
## Summary
- add PACKAGING_WIN.md with step-by-step Windows packaging instructions, signing guidance, and artifact locations
- provide PySide6 deployment config, PowerShell bundling script, and Inno Setup installer definition for Windows builds
- create Windows GitHub Actions workflow plus repo ignores and placeholder assets for local icon management

## Testing
- not run (documentation and configuration updates only)


------
https://chatgpt.com/codex/tasks/task_e_68cb85741cb0832695f839f2b6e90106