### PR TITLE
Update Qt Quick Dialogs import for Qt6

### DIFF
--- a/normal2disp/gui/qml/LeftPanel.qml
+++ b/normal2disp/gui/qml/LeftPanel.qml
@@ -1,7 +1,7 @@
 import QtQuick 2.15
 import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.15
-import QtQuick.Dialogs 1.3
+import QtQuick.Dialogs
 
 Item {
     id: root
@@ -532,7 +532,6 @@ Item {
             if (backend) {
                 backend.setNormalPath(cleanPath(selectedFile))
             }
-
         }
     }
 
@@ -543,7 +542,6 @@ Item {
             if (backend) {
                 backend.setOutputDirectory(cleanPath(selectedFolder))
             }
-
         }
     }
 


### PR DESCRIPTION
## Summary
- switch the LeftPanel QML file to use the Qt 6 style QtQuick.Dialogs import
- ensure the file and folder dialogs read the Qt 6 selectedFile/selectedFolder properties when updating backend paths

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cb917f0b8c832684c82328e41d8f09