### PR TITLE
Fix amplitude field for Qt6 spin box

### DIFF
--- a/normal2disp/gui/qml/LeftPanel.qml
+++ b/normal2disp/gui/qml/LeftPanel.qml
@@ -1,7 +1,7 @@
 import QtQuick 2.15
 import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.15
-import QtQuick.Dialogs 1.3
+import QtQuick.Dialogs
 
 Item {
     id: root
@@ -234,18 +234,36 @@ Item {
                             to: 10
                             value: 1
                             Layout.fillWidth: true
-                            onMoved: amplitudeSpin.value = value
+                            onValueChanged: amplitudeField.updateFromSlider(value)
                         }
 
-                        SpinBox {
-                            id: amplitudeSpin
-                            from: 0
-                            to: 10
-                            stepSize: 0.1
-                            value: amplitudeSlider.value
-                            editable: true
+                        TextField {
+                            id: amplitudeField
                             Layout.preferredWidth: 80
-                            onValueModified: amplitudeSlider.value = value
+                            text: amplitudeSlider.value.toFixed(1)
+                            horizontalAlignment: Text.AlignHCenter
+                            validator: DoubleValidator {
+                                bottom: amplitudeSlider.from
+                                top: amplitudeSlider.to
+                                decimals: 1
+                            }
+                            inputMethodHints: Qt.ImhFormattedNumbersOnly
+
+                            function updateFromSlider(value) {
+                                if (!focus) {
+                                    text = value.toFixed(1)
+                                }
+                            }
+
+                            onEditingFinished: {
+                                var parsed = Number(text)
+                                if (isNaN(parsed)) {
+                                    parsed = amplitudeSlider.value
+                                }
+                                parsed = Math.max(amplitudeSlider.from, Math.min(amplitudeSlider.to, parsed))
+                                amplitudeSlider.value = parsed
+                                text = parsed.toFixed(1)
+                            }
                         }
                     }
 
@@ -532,7 +550,6 @@ Item {
             if (backend) {
                 backend.setNormalPath(cleanPath(selectedFile))
             }
-
         }
     }
 
@@ -543,7 +560,6 @@ Item {
             if (backend) {
                 backend.setOutputDirectory(cleanPath(selectedFolder))
             }
-
         }
     }
 


### PR DESCRIPTION
## Summary
- replace the amplitude SpinBox with a validated TextField so Qt 6 no longer reports an int-only step size error
- keep the amplitude slider and numeric entry synchronized while enforcing the 0–10 range

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cb917f0b8c832684c82328e41d8f09