### PR TITLE
Fix Qt Quick 3D import version

### DIFF
--- a/normal2disp/gui/qml/Viewport.qml
+++ b/normal2disp/gui/qml/Viewport.qml
@@ -1,8 +1,8 @@
 import QtQuick 2.15
 import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.15
-import QtQuick3D 1.15
-import QtQuick3D.Helpers 1.15
+import QtQuick3D
+import QtQuick3D.Helpers
 
 Item {
     id: root


### PR DESCRIPTION
## Summary
- load Qt Quick 3D without a pinned 1.x import so the module resolves under Qt 6

## Testing
- not run (QML-only change)

------
https://chatgpt.com/codex/tasks/task_e_68cbb2b5d60c8326afb90b724333327f