### PR TITLE
Fix OrbitCameraController property for Qt 3D viewport

### DIFF
--- a/normal2disp/gui/qml/Viewport.qml
+++ b/normal2disp/gui/qml/Viewport.qml
@@ -91,7 +91,6 @@ Item {
             linearSpeed: 2
             lookAt: Qt.vector3d(0, 0, 0)
             zoomSpeed: 0.2
-            panSpeed: 0.8
         }
     }
 


### PR DESCRIPTION
## Summary
- remove the unsupported `panSpeed` assignment from `Viewport.qml`
- rely on the default pan handling provided by `OrbitCameraController`

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cbb46c2a888326abec2b5400b1d4e9